### PR TITLE
2303 Add extensions to process models

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-api-impl/src/main/java/org/activiti/cloud/organization/api/impl/ModelImpl.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api-impl/src/main/java/org/activiti/cloud/organization/api/impl/ModelImpl.java
@@ -19,13 +19,10 @@ package org.activiti.cloud.organization.api.impl;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.activiti.cloud.organization.api.Extensions;
 import org.activiti.cloud.organization.api.Model;
-import org.activiti.cloud.organization.api.impl.ModelView.ContentView;
-import org.activiti.cloud.organization.api.impl.ModelView.ExportView;
-import org.activiti.cloud.organization.api.impl.ModelView.MetadataView;
 import org.activiti.cloud.services.auditable.AbstractAuditable;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
@@ -42,23 +39,18 @@ public class ModelImpl extends AbstractAuditable<String> implements Model<Applic
     private String id;
 
     @ApiModelProperty("The name of the model")
-    @JsonView({MetadataView.class, ExportView.class})
     private String name;
 
     @ApiModelProperty(value = "The type of the model", readOnly = true)
-    @JsonView({MetadataView.class, ExportView.class})
     private String type;
 
     @ApiModelProperty(value = "The version of the model", readOnly = true)
-    @JsonView({MetadataView.class, ExportView.class})
     private String version;
 
     @ApiModelProperty(value = "The content type of the model", readOnly = true, hidden = true)
-    @JsonView({ExportView.class, ContentView.class})
     private String contentType;
 
     @ApiModelProperty(value = "The content of the model", readOnly = true, hidden = true)
-    @JsonView({ExportView.class, ContentView.class})
     private String content;
 
     @ApiModelProperty(hidden = true)
@@ -66,8 +58,10 @@ public class ModelImpl extends AbstractAuditable<String> implements Model<Applic
     private ApplicationImpl application;
 
     @ApiModelProperty("The parent application id")
-    @JsonView(MetadataView.class)
     private String applicationId;
+
+    @ApiModelProperty(value = "The extensions of the model", readOnly = true)
+    private Extensions extensions;
 
     public ModelImpl() {
 
@@ -154,6 +148,16 @@ public class ModelImpl extends AbstractAuditable<String> implements Model<Applic
     @Override
     public void setContent(String content) {
         this.content = content;
+    }
+
+    @Override
+    public Extensions getExtensions() {
+        return extensions;
+    }
+
+    @Override
+    public void setExtensions(Extensions extensions) {
+        this.extensions = extensions;
     }
 
     @Override

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/Extensions.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/Extensions.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.organization.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Model extensions
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class Extensions {
+
+    @JsonProperty("properties")
+    private Map<String, ProcessVariable> processVariables = new HashMap<>();
+
+    private Map<String, Map<VariableMappingType, Map<String, String>>> variablesMappings = new HashMap<>();
+
+    public Map<String, ProcessVariable> getProcessVariables() {
+        return processVariables;
+    }
+
+    public void setProcessVariables(Map<String, ProcessVariable> processVariables) {
+        this.processVariables = processVariables;
+    }
+
+    public Map<String, Map<VariableMappingType, Map<String, String>>> getVariablesMappings() {
+        return variablesMappings;
+    }
+
+    public void setVariablesMappings(Map<String, Map<VariableMappingType, Map<String, String>>> variablesMappings) {
+        this.variablesMappings = variablesMappings;
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/Model.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/Model.java
@@ -50,4 +50,8 @@ public interface Model<A extends Application, U> extends Auditable<U> {
     String getContent();
 
     void setContent(String content);
+
+    Extensions getExtensions();
+
+    void setExtensions(Extensions extensions);
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/ProcessVariable.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/ProcessVariable.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.organization.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Process variable
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class ProcessVariable {
+
+    private String id;
+
+    private String name;
+
+    private String type;
+
+    private boolean required;
+
+    private String value;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/VariableMappingType.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/VariableMappingType.java
@@ -13,23 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.activiti.cloud.organization.api;
 
-package org.activiti.cloud.organization.api.impl;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * Model view interface to be used in defining json views for models.
+ * Extensions service parameter
  */
-public interface ModelView {
+public enum VariableMappingType {
+    INPUT,
+    OUTPUT;
 
-    interface ContentView extends ModelView {
-
+    @JsonCreator
+    public static VariableMappingType fromValue(String value) {
+        return Optional.ofNullable(value)
+                .map(String::toUpperCase)
+                .map(VariableMappingType::valueOf)
+                .orElse(null);
     }
 
-    interface MetadataView extends ModelView {
-
-    }
-
-    interface ExportView extends ModelView {
-
-    }
-}
+    @JsonValue
+    public String getValue() {
+        return name().toLowerCase();
+    }}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-core/src/main/java/org/activiti/cloud/organization/converter/JsonConverter.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-core/src/main/java/org/activiti/cloud/organization/converter/JsonConverter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.activiti.cloud.services.organization.service;
+package org.activiti.cloud.organization.converter;
 
 import java.io.IOException;
 import java.util.Optional;

--- a/activiti-cloud-services-org/activiti-cloud-services-org-core/src/main/java/org/activiti/cloud/organization/core/rest/client/model/ModelReference.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-core/src/main/java/org/activiti/cloud/organization/core/rest/client/model/ModelReference.java
@@ -36,6 +36,8 @@ public class ModelReference {
 
     private String content;
 
+    private String extensions;
+
     private String version;
 
     public ModelReference() {
@@ -78,6 +80,14 @@ public class ModelReference {
 
     public void setContentType(String contentType) {
         this.contentType = contentType;
+    }
+
+    public String getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(String extensions) {
+        this.extensions = extensions;
     }
 
     public String getVersion() {

--- a/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ModelEntity.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ModelEntity.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.activiti.cloud.organization.api.Extensions;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.core.rest.client.model.ModelReference;
 import org.activiti.cloud.services.organization.jpa.audit.AuditableEntity;
@@ -51,6 +52,9 @@ public class ModelEntity extends AuditableEntity<String> implements Model<Applic
     @Transient
     @JsonIgnore
     private ModelReference data;
+
+    @Transient
+    private Extensions extensions;
 
     public ModelEntity() { // for JPA
         this.data = new ModelReference();
@@ -153,5 +157,15 @@ public class ModelEntity extends AuditableEntity<String> implements Model<Applic
     @Override
     public void setContent(String content) {
         data.setContent(content);
+    }
+
+    @Override
+    public Extensions getExtensions() {
+        return extensions;
+    }
+
+    @Override
+    public void setExtensions(Extensions extensions) {
+        this.extensions = extensions;
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ObjectMapperJpaConfiguration.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ObjectMapperJpaConfiguration.java
@@ -18,10 +18,13 @@ package org.activiti.cloud.services.organization.entity;
 
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.activiti.cloud.organization.api.Application;
+import org.activiti.cloud.organization.api.Extensions;
 import org.activiti.cloud.organization.api.Model;
+import org.activiti.cloud.organization.converter.JsonConverter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -44,5 +47,11 @@ public class ObjectMapperJpaConfiguration {
 
         module.setAbstractTypes(resolver);
         return module;
+    }
+
+    @Bean
+    public JsonConverter<Extensions> extensionsConverter(ObjectMapper objectMapper) {
+        return new JsonConverter<>(Extensions.class,
+                                   objectMapper);
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/jpa/ModelJpaRepository.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/jpa/ModelJpaRepository.java
@@ -32,6 +32,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import static org.activiti.cloud.services.organization.entity.ModelEntityHandler.createModelReference;
 import static org.activiti.cloud.services.organization.entity.ModelEntityHandler.deleteModelReference;
+import static org.activiti.cloud.services.organization.entity.ModelEntityHandler.loadFullModelReference;
 import static org.activiti.cloud.services.organization.entity.ModelEntityHandler.loadModelReference;
 import static org.activiti.cloud.services.organization.entity.ModelEntityHandler.updateModelReference;
 
@@ -60,7 +61,7 @@ public interface ModelJpaRepository extends JpaRepository<ModelEntity, String>,
 
     @Override
     default Optional<ModelEntity> findModelById(String id) {
-        return findById(id).map(ModelEntityHandler::loadModelReference);
+        return findById(id).map(ModelEntityHandler::loadFullModelReference);
     }
 
     @Override
@@ -68,11 +69,6 @@ public interface ModelJpaRepository extends JpaRepository<ModelEntity, String>,
         return Optional.ofNullable(model.getContent())
                 .map(String::getBytes)
                 .orElse(new byte[0]);
-    }
-
-    @Override
-    default Class<?> getModelMetadataView() {
-        return null;
     }
 
     @Override
@@ -86,22 +82,23 @@ public interface ModelJpaRepository extends JpaRepository<ModelEntity, String>,
             model.setId(UUID.randomUUID().toString());
         }
         createModelReference(model);
-        return loadModelReference(save(model));
+        return loadFullModelReference(save(model));
     }
 
     @Override
     default ModelEntity updateModel(ModelEntity modelToBeUpdated,
                                     ModelEntity newModel) {
         modelToBeUpdated.setName(newModel.getName());
+        modelToBeUpdated.setExtensions(newModel.getExtensions());
         updateModelReference(modelToBeUpdated);
-        return loadModelReference(save(modelToBeUpdated));
+        return loadFullModelReference(save(modelToBeUpdated));
     }
 
     @Override
     default ModelEntity updateModelContent(ModelEntity modelToBeUpdated,
                                            FileContent fileContent) {
         updateModelReference(modelToBeUpdated);
-        return loadModelReference(save(modelToBeUpdated));
+        return loadFullModelReference(save(modelToBeUpdated));
     }
 
     @Override

--- a/activiti-cloud-services-org/activiti-cloud-services-org-repository/src/main/java/org/activiti/cloud/organization/repository/ModelRepository.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-repository/src/main/java/org/activiti/cloud/organization/repository/ModelRepository.java
@@ -51,6 +51,4 @@ public interface ModelRepository<A extends Application, M extends Model<A, ?>> {
     void deleteModel(M model);
 
     Class<M> getModelType();
-
-    Class<?> getModelMetadataView();
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/ModelingArgumentMatchers.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/ModelingArgumentMatchers.java
@@ -28,4 +28,8 @@ public class ModelingArgumentMatchers {
     public static ModelReference modelReferenceNamed(String name) {
         return argThat(modelReference -> modelReference.getName().equals(name));
     }
+
+    public static ModelReference modelReferenceWithExtensions(String extensions) {
+        return argThat(modelReference -> modelReference.getExtensions().equals(extensions));
+    }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ApplicationControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ApplicationControllerIT.java
@@ -52,14 +52,18 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.activiti.cloud.organization.api.ProcessModelType.PROCESS;
 import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteArray;
 import static org.activiti.cloud.services.organization.mock.MockFactory.application;
+import static org.activiti.cloud.services.organization.mock.MockFactory.extensions;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModelWithContent;
+import static org.activiti.cloud.services.organization.mock.MockFactory.processModelWithExtensions;
 import static org.activiti.cloud.services.organization.mock.ModelingArgumentMatchers.modelReferenceNamed;
 import static org.activiti.cloud.services.organization.rest.config.RepositoryRestConfig.API_VERSION;
 import static org.activiti.cloud.services.test.asserts.AssertResponseContent.assertThatResponseContent;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.AllOf.allOf;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -283,8 +287,9 @@ public class ApplicationControllerIT {
         Application application = application("application-with-models");
         ModelEntity processModel1 = processModelWithContent(processName1,
                                                             "Process Model Content 1");
-        ModelEntity processModel2 = processModelWithContent(processName2,
-                                                            "Process Model Content 2");
+        ModelEntity processModel2 = processModelWithExtensions(processName2,
+                                                               extensions("var1",
+                                                                          "var2"));
 
         doReturn(processModel1.getData())
                 .when(modelReferenceService)
@@ -346,15 +351,16 @@ public class ApplicationControllerIT {
                 .hasJsonContentSatisfying("processes/process-model-1.json",
                                           jsonContent -> jsonContent
                                                   .node("name").isEqualTo("process-model-1")
-                                                  .node("type").isEqualTo("PROCESS")
-                                                  .node("version").isEqualTo("0.0.1"))
+                                                  .node("type").isEqualTo("PROCESS"))
                 .hasContent("processes/process-model-2.bpmn20.xml",
-                            "Process Model Content 2")
+                            "")
                 .hasJsonContentSatisfying("processes/process-model-2.json",
                                           jsonContent -> jsonContent
                                                   .node("name").isEqualTo("process-model-2")
                                                   .node("type").isEqualTo("PROCESS")
-                                                  .node("version").isEqualTo("0.0.1"));
+                                                  .node("extensions.properties").matches(allOf(hasKey("var1"),
+                                                                                               hasKey("var2")))
+                );
     }
 
     @Test

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ApplicationService.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ApplicationService.java
@@ -26,6 +26,7 @@ import org.activiti.cloud.organization.api.Application;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.api.ModelType;
 import org.activiti.cloud.organization.api.ModelValidationError;
+import org.activiti.cloud.organization.converter.JsonConverter;
 import org.activiti.cloud.organization.core.error.ImportApplicationException;
 import org.activiti.cloud.organization.core.error.SemanticModelValidationException;
 import org.activiti.cloud.organization.repository.ApplicationRepository;
@@ -141,7 +142,7 @@ public class ApplicationService {
                                     .appendFile(modelService.exportModel(model),
                                                 folderName);
                             if (!isJsonContentType(model.getContentType())) {
-                                zipBuilder.appendFile(modelService.getModelMetadataFile(model),
+                                zipBuilder.appendFile(modelService.getModelMetadataFileContent(model),
                                                       folderName);
                             }
                         }));

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/JsonConverterConfiguration.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/JsonConverterConfiguration.java
@@ -19,6 +19,7 @@ package org.activiti.cloud.services.organization.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.organization.api.Application;
 import org.activiti.cloud.organization.api.Model;
+import org.activiti.cloud.organization.converter.JsonConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
@@ -30,6 +30,7 @@ import org.activiti.cloud.organization.api.Application;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.api.ModelType;
 import org.activiti.cloud.organization.api.ModelValidator;
+import org.activiti.cloud.organization.converter.JsonConverter;
 import org.activiti.cloud.organization.core.error.ImportModelException;
 import org.activiti.cloud.organization.core.error.UnknownModelTypeException;
 import org.activiti.cloud.organization.repository.ModelRepository;
@@ -134,27 +135,25 @@ public class ModelService {
         }
     }
 
-    public FileContent getModelMetadataFile(Model model) {
-        Class<?> metadataView = modelRepository.getModelMetadataView();
+    public FileContent getModelMetadataFileContent(Model model) {
         Model modelWithFullMetadata = findModelById(model.getId()).orElse(model);
         return new FileContent(toJsonFilename(model.getName()),
                                ContentTypeUtils.CONTENT_TYPE_JSON,
-                               jsonConverter.convertToJsonBytes(modelWithFullMetadata,
-                                                                metadataView));
+                               jsonConverter.convertToJsonBytes(modelWithFullMetadata));
     }
 
     public FileContent getModelContentFile(Model model) {
-        return getModelViewFile(model,
-                                modelRepository.getModelContent(model));
+        return getModelFileContent(model,
+                                   modelRepository.getModelContent(model));
     }
 
     public FileContent exportModel(Model model) {
-        return getModelViewFile(model,
-                                modelRepository.getModelExport(model));
+        return getModelFileContent(model,
+                                   modelRepository.getModelExport(model));
     }
 
-    private FileContent getModelViewFile(Model model,
-                                         byte[] modelBytes) {
+    private FileContent getModelFileContent(Model model,
+                                            byte[] modelBytes) {
         return new FileContent(setExtension(model.getName(),
                                             findModelType(model).getContentFileExtension()),
                                model.getContentType(),


### PR DESCRIPTION
- add Extensions, ProcessVaraible and VariableMappingType
- add extensions to ModelImpl and ModelEntity
- update ModelReference with the extensions string comming from process-model service
- move JsonConverter to core for a larger accesability
- use JsonConverter<Extensions> in jpa to serialize/deserialize extensions
- get ride of not used anymore ModelViews
- add tests for create, get and update model with extensins

https://github.com/Activiti/Activiti/issues/2303