### PR TITLE
2639 fix model validation for wrong content type + add template field in models

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-api-impl/src/main/java/org/activiti/cloud/organization/api/impl/ModelImpl.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api-impl/src/main/java/org/activiti/cloud/organization/api/impl/ModelImpl.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.activiti.cloud.organization.api.Extensions;
+import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.services.auditable.AbstractAuditable;
 
@@ -62,6 +62,9 @@ public class ModelImpl extends AbstractAuditable<String> implements Model<Projec
 
     @ApiModelProperty(value = "The extensions of the model", readOnly = true)
     private Extensions extensions;
+
+    @ApiModelProperty(value = "The template of the model", readOnly = true)
+    private String template;
 
     public ModelImpl() {
 
@@ -157,6 +160,16 @@ public class ModelImpl extends AbstractAuditable<String> implements Model<Projec
     @Override
     public void setExtensions(Extensions extensions) {
         this.extensions = extensions;
+    }
+
+    @Override
+    public String getTemplate() {
+        return template;
+    }
+
+    @Override
+    public void setTemplate(String template) {
+        this.template = template;
     }
 
     @Override

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/Model.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/Model.java
@@ -16,6 +16,7 @@
 
 package org.activiti.cloud.organization.api;
 
+import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.services.auditable.Auditable;
 
 /**
@@ -52,4 +53,8 @@ public interface Model<A extends Project, U> extends Auditable<U> {
     Extensions getExtensions();
 
     void setExtensions(Extensions extensions);
+
+    String getTemplate();
+
+    void setTemplate(String template);
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/ModelContent.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/ModelContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,25 +17,11 @@
 package org.activiti.cloud.organization.api;
 
 /**
- * Business logic related with validation of a model content
+ * Interface for model content
  */
-public interface ModelValidator {
+public interface ModelContent {
 
-    /**
-     * Validate the given model content.
-     * @param modelContent the model content to validate
-     */
-    void validateModelContent(byte[] modelContent);
+    String getId();
 
-    /**
-     * Get handled model type by this validator.
-     * @return handled model type
-     */
-    ModelType getHandledModelType();
-
-    /**
-     * Get handled content type by this validator.
-     * @return handled content type
-     */
-    String getHandledContentType();
+    String getTemplate();
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/ModelContentConverter.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/ModelContentConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.organization.api;
+
+import java.util.Optional;
+
+/**
+ * Model content converter interface
+ */
+public interface ModelContentConverter<T extends ModelContent> {
+
+    /**
+     * Get handled model type by this converter.
+     * @return handled model type
+     */
+    ModelType getHandledModelType();
+
+    /**
+     * Convert a bytes array to the handled model content entity.
+     * @param bytes the bytes to convert
+     * @return the model content, or {@link Optional#empty()}
+     */
+    Optional<T> convertToModelContent(byte[] bytes);
+
+    /**
+     * Convert an instance of the model content to bytes array
+     * @param modelContent the model content instance to convert
+     * @return the bytes array
+     */
+    byte[] convertToBytes(T modelContent);
+
+    /**
+     * Convert a bytes array to the handled model content entity, set the given id, and convert back to bytes array.
+     * If the id is already the expected one, it returns the given bytes unchanged.
+     * @param bytes the bytes to convert and fix
+     * @param modelContentId the correct model content id to set
+     * @return the fixed bytes array
+     */
+    default byte[] convertAndFixModelContentId(byte[] bytes,
+                                               String modelContentId) {
+        return bytes;
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/Extensions.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/Extensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.organization.api;
+package org.activiti.cloud.organization.api.process;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/ProcessVariable.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/ProcessVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.organization.api;
+package org.activiti.cloud.organization.api.process;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/ProcessVariableMapping.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/ProcessVariableMapping.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.organization.api.process;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Process variable mapping item
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class ProcessVariableMapping {
+
+    private VariableMappingType type;
+
+    private String value;
+
+    public VariableMappingType getType() {
+        return type;
+    }
+
+    public void setType(VariableMappingType type) {
+        this.type = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/ServiceTaskActionType.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/ServiceTaskActionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.organization.api;
+package org.activiti.cloud.organization.api.process;
 
 import java.util.Optional;
 

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/VariableMappingType.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/VariableMappingType.java
@@ -14,17 +14,30 @@
  * limitations under the License.
  */
 
-package org.activiti.cloud.services.organization.entity;
+package org.activiti.cloud.organization.api.process;
 
-import org.activiti.cloud.organization.api.process.Extensions;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * Jon to model extensions converter
+ * Extensions variable mapping types
  */
-public class ExtensionsJsonConverter extends JpaJsonConverter<Extensions> {
+public enum VariableMappingType {
+    VARIABLE,
+    VALUE;
 
-    @Override
-    protected Class<Extensions> getEntityClass() {
-        return Extensions.class;
+    @JsonCreator
+    public static VariableMappingType fromValue(String value) {
+        return Optional.ofNullable(value)
+                .map(String::toUpperCase)
+                .map(VariableMappingType::valueOf)
+                .orElse(null);
+    }
+
+    @JsonValue
+    public String getValue() {
+        return name().toLowerCase();
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ModelEntity.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ModelEntity.java
@@ -32,8 +32,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.activiti.cloud.organization.api.Extensions;
 import org.activiti.cloud.organization.api.Model;
+import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.services.organization.jpa.audit.AuditableEntity;
 import org.activiti.cloud.services.organization.jpa.version.VersionedEntity;
 import org.hibernate.annotations.GenericGenerator;
@@ -69,6 +69,8 @@ public class ModelEntity extends AuditableEntity<String> implements Model<Projec
     private String type;
 
     private String name;
+
+    private String template;
 
     public ModelEntity() { // for JPA
     }
@@ -163,6 +165,16 @@ public class ModelEntity extends AuditableEntity<String> implements Model<Projec
     @Override
     public void setExtensions(Extensions extensions) {
         latestVersion.setExtensions(extensions);
+    }
+
+    @Override
+    public String getTemplate() {
+        return template;
+    }
+
+    @Override
+    public void setTemplate(String template) {
+        this.template = template;
     }
 
     @Override

--- a/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ModelVersionEntity.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ModelVersionEntity.java
@@ -29,7 +29,7 @@ import javax.persistence.Transient;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.activiti.cloud.organization.api.Extensions;
+import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.services.organization.jpa.audit.AuditableEntity;
 import org.activiti.cloud.services.organization.jpa.version.VersionEntity;
 import org.activiti.cloud.services.organization.jpa.version.VersionIdentifier;

--- a/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ObjectMapperJpaConfiguration.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ObjectMapperJpaConfiguration.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.activiti.cloud.organization.api.Project;
-import org.activiti.cloud.organization.api.Extensions;
+import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.converter.JsonConverter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/MockFactory.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/MockFactory.java
@@ -23,17 +23,17 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
-import org.activiti.cloud.organization.api.Extensions;
-import org.activiti.cloud.organization.api.ProcessVariable;
-import org.activiti.cloud.organization.api.ProcessVariableMapping;
+import org.activiti.cloud.organization.api.process.Extensions;
+import org.activiti.cloud.organization.api.process.ProcessVariable;
+import org.activiti.cloud.organization.api.process.ProcessVariableMapping;
 import org.activiti.cloud.services.organization.entity.ModelEntity;
 import org.activiti.cloud.services.organization.entity.ProjectEntity;
 
 import static java.util.Collections.singletonMap;
 import static org.activiti.cloud.organization.api.ProcessModelType.PROCESS;
-import static org.activiti.cloud.organization.api.ServiceTaskActionType.INPUTS;
-import static org.activiti.cloud.organization.api.ServiceTaskActionType.OUTPUTS;
-import static org.activiti.cloud.organization.api.VariableMappingType.VALUE;
+import static org.activiti.cloud.organization.api.process.ServiceTaskActionType.INPUTS;
+import static org.activiti.cloud.organization.api.process.ServiceTaskActionType.OUTPUTS;
+import static org.activiti.cloud.organization.api.process.VariableMappingType.VALUE;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_XML;
 
 /**

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/MockFactory.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/MockFactory.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
+import org.activiti.cloud.organization.api.ConnectorModelType;
 import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.organization.api.process.ProcessVariable;
 import org.activiti.cloud.organization.api.process.ProcessVariableMapping;
@@ -154,6 +155,11 @@ public class MockFactory {
         processVariableMapping.setType(VALUE);
         processVariableMapping.setValue(name);
         return processVariableMapping;
+    }
+
+    public static ModelEntity connectorModel(String name) {
+        return new ModelEntity(name,
+                               ConnectorModelType.NAME);
     }
 
     public static String id() {

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/MockMultipartRequestBuilder.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/MockMultipartRequestBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.organization.mock;
+
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+
+import static org.springframework.http.HttpMethod.PUT;
+
+/**
+ * Builder for multipart MockMvc requests.
+ * It can be used for making PUT with multipart calls.
+ */
+public class MockMultipartRequestBuilder {
+
+    private MockMultipartHttpServletRequestBuilder multipartRequestBuilder;
+
+    MockMultipartRequestBuilder(MockMultipartHttpServletRequestBuilder multipartRequestBuilder) {
+        this.multipartRequestBuilder = multipartRequestBuilder;
+    }
+
+    public static MockMultipartRequestBuilder putMultipart(String urlTemplate,
+                                                           Object... uriVars) {
+        return multipart(urlTemplate,
+                         uriVars)
+                .put();
+    }
+
+    public static MockMultipartRequestBuilder multipart(String urlTemplate,
+                                                        Object... uriVars) {
+        return new MockMultipartRequestBuilder(
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart(urlTemplate,
+                                                                                              uriVars));
+    }
+
+    public MockMultipartRequestBuilder put() {
+        multipartRequestBuilder.with(request -> {
+            request.setMethod(PUT.name());
+            return request;
+        });
+        return this;
+    }
+
+    public MockMultipartHttpServletRequestBuilder file(MockMultipartFile file) {
+        multipartRequestBuilder.file(file);
+        return multipartRequestBuilder;
+    }
+
+    public MockMultipartHttpServletRequestBuilder file(String controlName,
+                                                       String fileName,
+                                                       String contentType,
+                                                       byte[] bytes) {
+        return file(new MockMultipartFile(controlName,
+                                          fileName,
+                                          contentType,
+                                          bytes));
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelControllerIT.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.organization.api.ConnectorModelType;
-import org.activiti.cloud.organization.api.Extensions;
+import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.api.ModelValidationError;
 import org.activiti.cloud.organization.api.Project;

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelControllerIT.java
@@ -20,10 +20,10 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.organization.api.ConnectorModelType;
-import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.api.ModelValidationError;
 import org.activiti.cloud.organization.api.Project;
+import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.organization.core.error.SemanticModelValidationException;
 import org.activiti.cloud.organization.repository.ModelRepository;
 import org.activiti.cloud.organization.repository.ProjectRepository;
@@ -52,11 +52,13 @@ import static org.activiti.cloud.organization.api.ProcessModelType.PROCESS;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_JSON;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_XML;
 import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteArray;
+import static org.activiti.cloud.services.organization.mock.MockFactory.connectorModel;
 import static org.activiti.cloud.services.organization.mock.MockFactory.extensions;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModel;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModelWithContent;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModelWithExtensions;
 import static org.activiti.cloud.services.organization.mock.MockFactory.project;
+import static org.activiti.cloud.services.organization.mock.MockMultipartRequestBuilder.putMultipart;
 import static org.activiti.cloud.services.organization.rest.config.RepositoryRestConfig.API_VERSION;
 import static org.activiti.cloud.services.test.asserts.AssertResponseContent.assertThatResponseContent;
 import static org.assertj.core.api.Assertions.*;
@@ -368,11 +370,10 @@ public class ModelControllerIT {
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
                                    RepositoryRestConfig.API_VERSION,
-                                   processModel.getId()).file(file))
-                .andDo(print());
-
-        // then
-        resultActions.andExpect(status().isNoContent());
+                                   processModel.getId())
+                                 .file(file))
+                // then
+                .andExpect(status().isNoContent());
     }
 
     @Test
@@ -389,11 +390,10 @@ public class ModelControllerIT {
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
                                    RepositoryRestConfig.API_VERSION,
-                                   processModel.getId()).file(file))
-                .andDo(print());
-
-        // then
-        resultActions.andExpect(status().isBadRequest());
+                                   processModel.getId())
+                                 .file(file))
+                // then
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -410,14 +410,12 @@ public class ModelControllerIT {
                                                                                     new Extensions()));
 
         // when
-        final ResultActions resultActions = mockMvc
-                .perform(multipart("{version}/models/{model_id}/validate",
-                                   RepositoryRestConfig.API_VERSION,
-                                   processModel.getId()).file(file))
-                .andDo(print());
-
-        // then
-        resultActions.andExpect(status().isNoContent());
+        mockMvc.perform(multipart("{version}/models/{model_id}/validate",
+                                  RepositoryRestConfig.API_VERSION,
+                                  processModel.getId())
+                                .file(file))
+                // then
+                .andExpect(status().isNoContent());
     }
 
     @Test
@@ -464,14 +462,69 @@ public class ModelControllerIT {
                                                        "text/plain",
                                                        "BPMN diagram".getBytes());
         // when
-        final ResultActions resultActions = mockMvc
-                .perform(multipart("{version}/models/{model_id}/validate",
-                                   RepositoryRestConfig.API_VERSION,
-                                   "model_id").file(file))
-                .andDo(print());
+        mockMvc.perform(multipart("{version}/models/{model_id}/validate",
+                                  RepositoryRestConfig.API_VERSION,
+                                  "model_id")
+                                .file(file))
+                // then
+                .andExpect(status().isNotFound());
+    }
 
-        // then
-        resultActions.andExpect(status().isNotFound());
+    @Test
+    public void validateInvalidProcessModelUsingTextContentType() throws Exception {
+
+        // given
+        MockMultipartFile file = new MockMultipartFile("file",
+                                                       "diagram.bpmn20.xml",
+                                                       "text/plain",
+                                                       "BPMN diagram".getBytes());
+        Model processModel = modelRepository.createModel(processModel("Process-Model"));
+
+        // when
+        mockMvc.perform(multipart("{version}/models/{model_id}/validate",
+                                  API_VERSION,
+                                  processModel.getId())
+                                .file(file))
+                // then
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void validateConnectorValidContent() throws Exception {
+        // given
+        byte[] validContent = resourceAsByteArray("connector/connector-simple.json");
+        MockMultipartFile file = new MockMultipartFile("file",
+                                                       "connector-simple.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       validContent);
+        Model connectorModel = modelRepository.createModel(connectorModel("Connector-Model"));
+
+        // when
+        mockMvc.perform(multipart("{version}/models/{model_id}/validate",
+                                  API_VERSION,
+                                  connectorModel.getId())
+                                .file(file))
+                // then
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void validateConnectorValidContentWithTemplate() throws Exception {
+        // given
+        byte[] validContent = resourceAsByteArray("connector/connector-template.json");
+        MockMultipartFile file = new MockMultipartFile("file",
+                                                       "connector-template.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       validContent);
+        Model connectorModel = modelRepository.createModel(connectorModel("Connector-Model"));
+
+        // when
+        mockMvc.perform(multipart("{version}/models/{model_id}/validate",
+                                  API_VERSION,
+                                  connectorModel.getId())
+                                .file(file))
+                // then
+                .andExpect(status().isNoContent());
     }
 
     @Test
@@ -595,5 +648,54 @@ public class ModelControllerIT {
                 // THEN
                 .andDo(print())
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testUpdateConnectorTemplate() throws Exception {
+        //GIVEN
+        Model connectorModel = modelRepository.createModel(connectorModel("Connector With Template"));
+
+        // WHEN
+        mockMvc.perform(putMultipart("{version}/models/{modelId}/content",
+                                     API_VERSION,
+                                     connectorModel.getId())
+                                .file("file",
+                                      "connector-template.json",
+                                      "application/json",
+                                      resourceAsByteArray("connector/connector-template.json")))
+                .andExpect(status().isNoContent());
+
+        // THEN
+        mockMvc.perform(get("{version}/models/{modelId}",
+                            API_VERSION,
+                            connectorModel.getId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.template",
+                                    is("ConnectorTemplate")));
+    }
+
+    @Test
+    public void testUpdateConnectorCustom() throws Exception {
+        //GIVEN
+        Model connectorModel = modelRepository.createModel(connectorModel("SimpleConnector"));
+
+        // WHEN
+        mockMvc.perform(putMultipart("{version}/models/{modelId}/content",
+                                     API_VERSION,
+                                     connectorModel.getId())
+                                .file("file",
+                                      "connector-simple.json",
+                                      "application/json",
+                                      resourceAsByteArray("connector/connector-simple.json")))
+                .andExpect(status().isNoContent());
+
+        // THEN
+        mockMvc.perform(get("{version}/models/{modelId}",
+                            API_VERSION,
+                            connectorModel.getId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.template").doesNotExist());
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/connector/connector-simple.json
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/connector/connector-simple.json
@@ -1,0 +1,41 @@
+{
+  "name": "Name-of-the-connector",
+  "description": "Description of the connector",
+  "actions": {
+    "actionId1": {
+      "id": "actionId1",
+      "name": "actionName1",
+      "description": "description",
+      "inputs": [
+        {
+          "id": "input-variable-1",
+          "name": "input-variable-name-1",
+          "type": "string",
+          "required": false,
+          "description": "description"
+        },
+        {
+          "id": "input-variable-2",
+          "name": "input-variable-name-2",
+          "type": "boolean",
+          "required": false,
+          "description": ""
+        }
+      ],
+      "outputs": [
+        {
+          "id": "output-variable-1",
+          "name": "output-variable-name-1",
+          "type": "string",
+          "description": ""
+        },
+        {
+          "id": "output-variable-2",
+          "name": "output-variable-name-2",
+          "type": "string",
+          "description": ""
+        }
+      ]
+    }
+  }
+} 

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/connector/connector-template.json
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/connector/connector-template.json
@@ -1,0 +1,42 @@
+{
+  "name": "Name-of-the-connector",
+  "description": "Description of the connector",
+  "template": "ConnectorTemplate",
+  "actions": {
+    "actionId1": {
+      "id": "actionId1",
+      "name": "actionName1",
+      "description": "description",
+      "inputs": [
+        {
+          "id": "input-variable-1",
+          "name": "input-variable-name-1",
+          "type": "string",
+          "required": false,
+          "description": "description"
+        },
+        {
+          "id": "input-variable-2",
+          "name": "input-variable-name-2",
+          "type": "boolean",
+          "required": false,
+          "description": ""
+        }
+      ],
+      "outputs": [
+        {
+          "id": "output-variable-1",
+          "name": "output-variable-name-1",
+          "type": "string",
+          "description": ""
+        },
+        {
+          "id": "output-variable-2",
+          "name": "output-variable-name-2",
+          "type": "string",
+          "description": ""
+        }
+      ]
+    }
+  }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/BpmnProcessModelContent.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/BpmnProcessModelContent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.organization.converter;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.Process;
+import org.activiti.cloud.organization.api.ModelContent;
+import org.activiti.cloud.organization.core.error.ModelingException;
+
+/**
+ * Implementation of {@link ModelContent} corresponding to process model type based on a {@link BpmnModel}
+ */
+public class BpmnProcessModelContent implements ModelContent {
+
+    private final BpmnModel bpmnModel;
+
+    private final Process process;
+
+    public BpmnProcessModelContent(BpmnModel bpmnModel) {
+        this.bpmnModel = bpmnModel;
+        this.process = bpmnModel
+                .getProcesses()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new ModelingException("Invalid bpmn model: no process id found"));
+    }
+
+    public BpmnModel getBpmnModel() {
+        return bpmnModel;
+    }
+
+    @Override
+    public String getId() {
+        return process.getId();
+    }
+
+    public BpmnProcessModelContent setId(String id) {
+        process.setId(id);
+        return this;
+    }
+
+    @Override
+    public String getTemplate() {
+        return null;
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ConnectorModelContent.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ConnectorModelContent.java
@@ -14,37 +14,40 @@
  * limitations under the License.
  */
 
-package org.activiti.cloud.organization.api;
+package org.activiti.cloud.services.organization.converter;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.activiti.cloud.organization.api.ModelContent;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 /**
- * Process variable mapping item
+ * Implementation for the {@link ModelContent} corresponding to connector model type
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
-public class ProcessVariableMapping {
+public class ConnectorModelContent implements ModelContent {
 
-    private VariableMappingType type;
+    private String id;
 
-    private String value;
+    private String template;
 
-    public VariableMappingType getType() {
-        return type;
+    @Override
+    public String getId() {
+        return id;
     }
 
-    public void setType(VariableMappingType type) {
-        this.type = type;
+    public void setId(String id) {
+        this.id = id;
     }
 
-    public String getValue() {
-        return value;
+    @Override
+    public String getTemplate() {
+        return template;
     }
 
-    public void setValue(String value) {
-        this.value = value;
+    public void setTemplate(String template) {
+        this.template = template;
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ConnectorModelContentConverter.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ConnectorModelContentConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.organization.converter;
+
+import java.util.Optional;
+
+import org.activiti.cloud.organization.api.ConnectorModelType;
+import org.activiti.cloud.organization.api.ModelContentConverter;
+import org.activiti.cloud.organization.api.ModelType;
+import org.activiti.cloud.organization.converter.JsonConverter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementation of {@link ModelContentConverter} for connectors models
+ */
+@Component
+public class ConnectorModelContentConverter implements ModelContentConverter<ConnectorModelContent> {
+
+    private final ConnectorModelType connectorModelType;
+
+    private final JsonConverter<ConnectorModelContent> connectorModelContentJsonConverter;
+
+    public ConnectorModelContentConverter(ConnectorModelType connectorModelType,
+                                          JsonConverter<ConnectorModelContent> connectorModelContentJsonConverter) {
+        this.connectorModelType = connectorModelType;
+        this.connectorModelContentJsonConverter = connectorModelContentJsonConverter;
+    }
+
+    @Override
+    public ModelType getHandledModelType() {
+        return connectorModelType;
+    }
+
+    @Override
+    public Optional<ConnectorModelContent> convertToModelContent(byte[] bytes) {
+        return Optional.ofNullable(connectorModelContentJsonConverter.convertToEntity(bytes));
+    }
+
+    @Override
+    public byte[] convertToBytes(ConnectorModelContent modelContent) {
+        return connectorModelContentJsonConverter.convertToJsonBytes(modelContent);
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ProcessModelContentConverter.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ProcessModelContentConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.organization.converter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Optional;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.activiti.bpmn.converter.BpmnXMLConverter;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.cloud.organization.api.ModelContentConverter;
+import org.activiti.cloud.organization.api.ModelType;
+import org.activiti.cloud.organization.api.ProcessModelType;
+import org.activiti.cloud.organization.core.error.ModelingException;
+import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.stereotype.Component;
+
+import static org.activiti.bpmn.converter.util.BpmnXMLUtil.createSafeXmlInputFactory;
+
+/**
+ * Implementation of {@link ModelContentConverter} for process models
+ */
+@Component
+public class ProcessModelContentConverter implements ModelContentConverter<BpmnProcessModelContent> {
+
+    private final ProcessModelType processModelType;
+
+    private final BpmnXMLConverter bpmnConverter;
+
+    public ProcessModelContentConverter(ProcessModelType processModelType,
+                                        BpmnXMLConverter bpmnConverter) {
+        this.bpmnConverter = bpmnConverter;
+        this.processModelType = processModelType;
+    }
+
+    @Override
+    public ModelType getHandledModelType() {
+        return processModelType;
+    }
+
+    @Override
+    public Optional<BpmnProcessModelContent> convertToModelContent(byte[] bytes) {
+        if (ArrayUtils.isEmpty(bytes)) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.ofNullable(convertToBpmnModel(bytes))
+                    .map(BpmnProcessModelContent::new);
+        } catch (IOException | XMLStreamException ex) {
+            throw new ModelingException("Invalid bpmn model",
+                                        ex);
+        }
+    }
+
+    @Override
+    public byte[] convertToBytes(BpmnProcessModelContent modelContent) {
+        return bpmnConverter.convertToXML(modelContent.getBpmnModel());
+    }
+
+    @Override
+    public byte[] convertAndFixModelContentId(byte[] bytes,
+                                               String modelContentId) {
+        return convertToModelContent(bytes)
+                .filter(modelContent -> !modelContentId.equals(modelContent.getId()))
+                .map(modelContent -> modelContent.setId(modelContentId))
+                .map(this::convertToBytes)
+                .orElse(bytes);
+    }
+
+    public BpmnModel convertToBpmnModel(byte[] modelContent) throws IOException, XMLStreamException {
+        try (InputStreamReader reader = new InputStreamReader(new ByteArrayInputStream(modelContent))) {
+            XMLStreamReader xmlReader = createSafeXmlInputFactory().createXMLStreamReader(reader);
+            return bpmnConverter.convertToBpmnModel(xmlReader);
+        }
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ProcessModelConverterConfiguration.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ProcessModelConverterConfiguration.java
@@ -13,31 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.activiti.cloud.services.organization.converter;
 
-package org.activiti.cloud.organization.api;
-
-import java.util.Optional;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import org.activiti.bpmn.converter.BpmnXMLConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
- * Extensions variable mapping types
+ * Configuration for process model validator
  */
-public enum VariableMappingType {
-    VARIABLE,
-    VALUE;
+@Configuration
+public class ProcessModelConverterConfiguration {
 
-    @JsonCreator
-    public static VariableMappingType fromValue(String value) {
-        return Optional.ofNullable(value)
-                .map(String::toUpperCase)
-                .map(VariableMappingType::valueOf)
-                .orElse(null);
-    }
-
-    @JsonValue
-    public String getValue() {
-        return name().toLowerCase();
+    @Bean
+    public BpmnXMLConverter bpmnXMLConverter() {
+        return new BpmnXMLConverter();
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/JsonConverterConfiguration.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/JsonConverterConfiguration.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.organization.api.Project;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.converter.JsonConverter;
+import org.activiti.cloud.services.organization.converter.ConnectorModelContent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -38,6 +39,12 @@ public class JsonConverterConfiguration {
     @Bean
     public JsonConverter<Model> modelJsonConverter(ObjectMapper objectMapper) {
         return new JsonConverter<>(Model.class,
+                                   objectMapper);
+    }
+
+    @Bean
+    public JsonConverter<ConnectorModelContent> connectorModelContentJsonConverter(ObjectMapper objectMapper) {
+        return new JsonConverter<>(ConnectorModelContent.class,
                                    objectMapper);
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelContentService.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelContentService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.organization.service;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.activiti.cloud.organization.api.Model;
+import org.activiti.cloud.organization.api.ModelContent;
+import org.activiti.cloud.organization.api.ModelContentConverter;
+import org.activiti.cloud.organization.api.ModelValidator;
+import org.springframework.stereotype.Service;
+
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_JSON;
+
+/**
+ * Service for managing {@link ModelValidator}
+ */
+@Service
+public class ModelContentService {
+
+    private final Map<String, ModelValidator> modelContentValidatorsMapByModelType;
+
+    private final Map<String, ModelValidator> modelJsonValidatorsMapByModelType;
+
+    private final Map<String, ModelContentConverter<? extends ModelContent>> modelContentConvertersMapByModelType;
+
+    public ModelContentService(ModelTypeService modelTypeService,
+                               Set<ModelValidator> modelValidators,
+                               Set<ModelContentConverter<? extends ModelContent>> modelConverters) {
+        this.modelContentValidatorsMapByModelType = modelValidators
+                .stream()
+                .filter(validator -> !CONTENT_TYPE_JSON.equals(validator.getHandledContentType()) ||
+                        modelTypeService.isJson(validator.getHandledModelType()))
+                .collect(Collectors.toMap(validator -> validator.getHandledModelType().getName(),
+                                          Function.identity()));
+
+        this.modelJsonValidatorsMapByModelType = modelValidators
+                .stream()
+                .filter(validator -> CONTENT_TYPE_JSON.equals(validator.getHandledContentType()))
+                .collect(Collectors.toMap(validator -> validator.getHandledModelType().getName(),
+                                          Function.identity()));
+
+        this.modelContentConvertersMapByModelType = modelConverters
+                .stream()
+                .collect(Collectors.toMap(converter -> converter.getHandledModelType().getName(),
+                                          Function.identity()));
+    }
+
+    public Optional<ModelValidator> findModelValidator(String modelType,
+                                                       String contentType) {
+        return Optional.ofNullable(CONTENT_TYPE_JSON.equals(contentType) ?
+                                           modelJsonValidatorsMapByModelType.get(modelType) :
+                                           modelContentValidatorsMapByModelType.get(modelType));
+    }
+
+    public Optional<ModelContentConverter<? extends ModelContent>> findModelContentConverter(String modelType) {
+        return Optional.ofNullable(modelContentConvertersMapByModelType.get(modelType));
+    }
+
+    public String getModelContentId(Model model) {
+        return String.join("-",
+                           model.getType().toLowerCase(),
+                           model.getId());
+    }
+
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/ConnectorModelValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/ConnectorModelValidator.java
@@ -47,7 +47,7 @@ public class ConnectorModelValidator extends JsonSchemaModelValidator {
     }
 
     @Override
-    public String getContentType() {
+    public String getHandledContentType() {
         return CONTENT_TYPE_JSON;
     }
 

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/ExtensionsModelValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/ExtensionsModelValidator.java
@@ -43,7 +43,7 @@ public class ExtensionsModelValidator extends JsonSchemaModelValidator {
     }
 
     @Override
-    public String getContentType() {
+    public String getHandledContentType() {
         return CONTENT_TYPE_JSON;
     }
 

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/ProcessModelValidatorConfiguration.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/ProcessModelValidatorConfiguration.java
@@ -33,9 +33,4 @@ public class ProcessModelValidatorConfiguration {
         processValidator.addValidatorSet(new ValidatorSetFactory().createActivitiExecutableProcessValidatorSet());
         return processValidator;
     }
-
-    @Bean
-    public BpmnXMLConverter bpmnXMLConverter() {
-        return new BpmnXMLConverter();
-    }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/resources/schema/connector-schema.json
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/resources/schema/connector-schema.json
@@ -69,12 +69,15 @@
       "description": "The connector's description",
       "type": "string"
     },
+    "template": {
+      "description": "The connector's template",
+      "type": "string"
+    },
     "actions" : {
       "type": "object",
       "additionalProperties": { "$ref": "#/definitions/connector-action" },
       "default": {}
     }
-
   },
   "required": [ "name" ]
 }


### PR DESCRIPTION
- add template field in models to be used for OOTB connectors
- update connectors schema to allow template field
- fix validation of process model and process extensions during process export
- fix find validator mechanism by model type and content type (by using two maps)
- move convertion functionality from validators to dedicated converters
- fix tests

https://github.com/Activiti/Activiti/issues/2639