### PR TITLE
2778 Don't allow projects with the same name

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-api-impl/src/main/java/org/activiti/cloud/organization/api/impl/ProjectImpl.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api-impl/src/main/java/org/activiti/cloud/organization/api/impl/ProjectImpl.java
@@ -39,6 +39,12 @@ public class ProjectImpl extends AbstractAuditable<String> implements Project<St
     @ApiModelProperty(value = "The name of the project")
     private String name;
 
+    @ApiModelProperty(value = "The description of the project")
+    private String description;
+
+    @ApiModelProperty(value = "The version of the project")
+    private String version;
+
     public ProjectImpl() {
 
     }
@@ -67,5 +73,25 @@ public class ProjectImpl extends AbstractAuditable<String> implements Project<St
     @Override
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/Project.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/Project.java
@@ -31,4 +31,11 @@ public interface Project<U> extends Auditable<U> {
 
     void setName(String name);
 
+    String getVersion();
+
+    void setVersion(String version);
+
+    String getDescription();
+
+    void setDescription(String description);
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ProjectEntity.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ProjectEntity.java
@@ -17,6 +17,7 @@
 package org.activiti.cloud.services.organization.entity;
 
 import java.util.List;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -48,7 +49,12 @@ public class ProjectEntity extends AuditableEntity<String> implements Project<St
     @GenericGenerator(name = "system-uuid", strategy = "uuid2")
     private String id;
 
+    @Column(unique = true)
     private String name;
+
+    private String description;
+
+    private String version;
 
     public ProjectEntity() {  // for JPA
     }
@@ -83,5 +89,25 @@ public class ProjectEntity extends AuditableEntity<String> implements Project<St
     @Override
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/main/java/org/activiti/cloud/services/organization/rest/controller/ModelingRestExceptionHandler.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/main/java/org/activiti/cloud/services/organization/rest/controller/ModelingRestExceptionHandler.java
@@ -17,25 +17,33 @@
 package org.activiti.cloud.services.organization.rest.controller;
 
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Map;
 import java.util.Optional;
+import javax.persistence.PersistenceException;
 import javax.servlet.http.HttpServletResponse;
 
-import org.activiti.cloud.organization.core.error.ImportProjectException;
 import org.activiti.cloud.organization.core.error.ImportModelException;
+import org.activiti.cloud.organization.core.error.ImportProjectException;
 import org.activiti.cloud.organization.core.error.SemanticModelValidationException;
 import org.activiti.cloud.organization.core.error.SyntacticModelValidationException;
 import org.activiti.cloud.organization.core.error.UnknownModelTypeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 /**
  * Handler for REST exceptions
@@ -44,7 +52,13 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class ModelingRestExceptionHandler {
 
+    private static final Logger logger = LoggerFactory.getLogger(ModelingRestExceptionHandler.class);
+
     public static final String ERRORS = "errors";
+
+    public static final String DATA_INTEGRITY_VIOLATION_EXCEPTION_MESSAGE = "Data integrity violation";
+
+    public static final String DATA_ACCESS_EXCEPTION_MESSAGE = "Data access error";
 
     @Bean
     public ErrorAttributes errorAttributes() {
@@ -74,7 +88,31 @@ public class ModelingRestExceptionHandler {
     })
     public void handleBadRequestException(Exception ex,
                                           HttpServletResponse response) throws IOException {
+        logger.error(ex.getMessage(),
+                     ex);
         response.sendError(BAD_REQUEST.value(),
                            ex.getMessage());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public void handleDataIntegrityViolationException(DataIntegrityViolationException ex,
+                                                      HttpServletResponse response) throws IOException {
+        logger.error(DATA_INTEGRITY_VIOLATION_EXCEPTION_MESSAGE,
+                     ex);
+        response.sendError(CONFLICT.value(),
+                           DATA_INTEGRITY_VIOLATION_EXCEPTION_MESSAGE);
+    }
+
+    @ExceptionHandler({
+            DataAccessException.class,
+            PersistenceException.class,
+            SQLException.class
+    })
+    public void handleDataAccessException(Exception ex,
+                                          HttpServletResponse response) throws IOException {
+        logger.error(DATA_ACCESS_EXCEPTION_MESSAGE,
+                     ex);
+        response.sendError(INTERNAL_SERVER_ERROR.value(),
+                           DATA_ACCESS_EXCEPTION_MESSAGE);
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/MockFactory.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/mock/MockFactory.java
@@ -50,6 +50,13 @@ public class MockFactory {
         return new ProjectEntity(name);
     }
 
+    public static ProjectEntity projectWithDescription(String name,
+                                                       String description) {
+        ProjectEntity project = new ProjectEntity(name);
+        project.setDescription(description);
+        return project;
+    }
+
     public static ModelEntity processModel(String name) {
         return processModelWithExtensions(name,
                                           null);

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ProjectService.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ProjectService.java
@@ -98,7 +98,10 @@ public class ProjectService {
      */
     public Project updateProject(Project projectToUpdate,
                                  Project newProject) {
-        projectToUpdate.setName(newProject.getName());
+        Optional.ofNullable(newProject.getDescription())
+                .ifPresent(projectToUpdate::setDescription);
+        Optional.ofNullable(newProject.getName())
+                .ifPresent(projectToUpdate::setName);
         return projectRepository.updateProject(projectToUpdate);
     }
 


### PR DESCRIPTION
- add unique constraint on ProjectEntity
- handle DataIntegrityViolationException as 409 Conflict
- update project name only if the name is present in payload
- add project description and version fields
- add tests for unique project name

https://github.com/activiti/activiti/issues/2778