### PR TITLE
[ACTIVITI-3454] - Revert Entity annotation on ModelEntity  to use the name attribute again

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ModelEntity.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-jpa/src/main/java/org/activiti/cloud/services/organization/entity/ModelEntity.java
@@ -45,7 +45,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 /**
  * Model model entity
  */
-@Entity
+@Entity(name = "Model")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
 @Table(name = "Model",


### PR DESCRIPTION
Actually, the ModelEntity class is annotated in this way
```@Entity```

and it generates the column name

```MODEL_ENTITY_ID```

Going back to

```@Entity(name` = "Model")```

gives back

```MODEL_ID```