### PR TITLE
ACTIVITI-3632 Process extensions validation: connector parameter names

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelControllerIT.java
@@ -32,7 +32,6 @@ import org.activiti.cloud.services.organization.entity.ModelEntity;
 import org.activiti.cloud.services.organization.entity.ProjectEntity;
 import org.activiti.cloud.services.organization.rest.config.RepositoryRestConfig;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -62,6 +61,7 @@ import static org.activiti.cloud.services.organization.mock.IsObjectEquals.isDat
 import static org.activiti.cloud.services.organization.mock.IsObjectEquals.isIntegerEquals;
 import static org.activiti.cloud.services.organization.mock.MockFactory.connectorModel;
 import static org.activiti.cloud.services.organization.mock.MockFactory.extensions;
+import static org.activiti.cloud.services.organization.mock.MockFactory.multipartExtensionsFile;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModel;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModelWithContent;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModelWithExtensions;
@@ -117,18 +117,23 @@ public class ModelControllerIT {
         //given
         ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("parent-project"));
 
-        modelRepository.createModel(processModel(project, "Process Model 1"));
-        modelRepository.createModel(processModel(project, "Process Model 2"));
+        modelRepository.createModel(processModel(project,
+                                                 "Process Model 1"));
+        modelRepository.createModel(processModel(project,
+                                                 "Process Model 2"));
 
         //when
         final ResultActions resultActions = mockMvc
                 .perform(get("{version}/projects/{projectId}/models?type=PROCESS",
-                        API_VERSION,
-                        project.getId()))
+                             API_VERSION,
+                             project.getId()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$._embedded.models", hasSize(2)))
-                .andExpect(jsonPath("$._embedded.models[0].name", is("Process Model 1")))
-                .andExpect(jsonPath("$._embedded.models[1].name", is("Process Model 2")));
+                .andExpect(jsonPath("$._embedded.models",
+                                    hasSize(2)))
+                .andExpect(jsonPath("$._embedded.models[0].name",
+                                    is("Process Model 1")))
+                .andExpect(jsonPath("$._embedded.models[1].name",
+                                    is("Process Model 2")));
     }
 
     @Test
@@ -138,17 +143,21 @@ public class ModelControllerIT {
 
         // WHEN
         mockMvc.perform(post("{version}/projects/{projectId}/models",
-                API_VERSION,
-                project.getId())
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
-                .content(mapper.writeValueAsString(processModel("process-model"))))
+                             API_VERSION,
+                             project.getId())
+                                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                                .content(mapper.writeValueAsString(processModel("process-model"))))
                 .andDo(print())
                 // THEN
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.name", equalTo("process-model")))
-                .andExpect(jsonPath("$.type", equalTo(PROCESS)))
-                .andExpect(jsonPath("$.extensions.properties", notNullValue()))
-                .andExpect(jsonPath("$.extensions.mappings", notNullValue()));
+                .andExpect(jsonPath("$.name",
+                                    equalTo("process-model")))
+                .andExpect(jsonPath("$.type",
+                                    equalTo(PROCESS)))
+                .andExpect(jsonPath("$.extensions.properties",
+                                    notNullValue()))
+                .andExpect(jsonPath("$.extensions.mappings",
+                                    notNullValue()));
     }
 
     @Test
@@ -158,16 +167,18 @@ public class ModelControllerIT {
 
         // WHEN
         mockMvc.perform(post("{version}/projects/{projectId}/models",
-                API_VERSION,
-                project.getId())
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
-                .content(mapper.writeValueAsString(connectorModel("connector-model"))))
+                             API_VERSION,
+                             project.getId())
+                                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                                .content(mapper.writeValueAsString(connectorModel("connector-model"))))
                 // THEN
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.name", equalTo("connector-model")))
-                .andExpect(jsonPath("$.type", equalTo(ConnectorModelType.NAME)))
-                .andExpect(jsonPath("$", hasNoJsonPath("extensions")));
-
+                .andExpect(jsonPath("$.name",
+                                    equalTo("connector-model")))
+                .andExpect(jsonPath("$.type",
+                                    equalTo(ConnectorModelType.NAME)))
+                .andExpect(jsonPath("$",
+                                    hasNoJsonPath("extensions")));
     }
 
     @Test
@@ -179,9 +190,11 @@ public class ModelControllerIT {
                                            "variable1",
                                            "variable2");
         extensions.setConstants(constantsFor("ServiceTask")
-        .add("myStringConstant", "myStringConstantValue")
-        .add("myIntegerConstant", 10)
-        .build());
+                                        .add("myStringConstant",
+                                             "myStringConstantValue")
+                                        .add("myIntegerConstant",
+                                             10)
+                                        .build());
         ModelEntity processModel = processModelWithExtensions("process-model-extensions",
                                                               extensions);
         // WHEN
@@ -216,14 +229,14 @@ public class ModelControllerIT {
 
                                       )))
                 .andExpect(jsonPath("$.extensions.constants",
-                             hasEntry(equalTo("ServiceTask"),
-                                      hasEntry(
-                                              equalTo("myIntegerConstant"),
-                                              hasEntry("value",
-                                                       10)
-                                      )
+                                    hasEntry(equalTo("ServiceTask"),
+                                             hasEntry(
+                                                     equalTo("myIntegerConstant"),
+                                                     hasEntry("value",
+                                                              10)
+                                             )
 
-                             )));
+                                    )));
     }
 
     @Test
@@ -232,14 +245,14 @@ public class ModelControllerIT {
         Project project = projectRepository.createProject(project("parent-project"));
 
         Model formModel = new ModelEntity("name",
-                "FORM");
+                                          "FORM");
 
         // WHEN
         mockMvc.perform(post("{version}/projects/{projectId}/models",
-                API_VERSION,
-                project.getId())
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
-                .content(mapper.writeValueAsString(formModel)))
+                             API_VERSION,
+                             project.getId())
+                                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                                .content(mapper.writeValueAsString(formModel)))
                 .andDo(print())
                 // THEN
                 .andExpect(status().isBadRequest());
@@ -250,14 +263,14 @@ public class ModelControllerIT {
         // GIVEN
         ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("parent-project"));
         modelRepository.createModel(processModel(project,
-                "process-model"));
+                                                 "process-model"));
 
         // WHEN
         mockMvc.perform(post("{version}/projects/{projectId}/models",
-                API_VERSION,
-                project.getId())
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
-                .content(mapper.writeValueAsString(processModel("process-model"))))
+                             API_VERSION,
+                             project.getId())
+                                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                                .content(mapper.writeValueAsString(processModel("process-model"))))
                 .andDo(print())
                 // THEN
                 .andExpect(status().isConflict());
@@ -270,8 +283,8 @@ public class ModelControllerIT {
 
         //then
         mockMvc.perform(get("{version}/models/{modelId}",
-                API_VERSION,
-                processModel.getId()))
+                            API_VERSION,
+                            processModel.getId()))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -281,132 +294,132 @@ public class ModelControllerIT {
         //given
         Model processModel = modelRepository
                 .createModel(processModelWithExtensions("process-model-with-extensions",
-                        extensions("ServiceTask",
-                                "stringVariable",
-                                "integerVariable",
-                                "booleanVariable",
-                                "dateVariable",
-                                "jsonVariable")));
+                                                        extensions("ServiceTask",
+                                                                   "stringVariable",
+                                                                   "integerVariable",
+                                                                   "booleanVariable",
+                                                                   "dateVariable",
+                                                                   "jsonVariable")));
         //when
         mockMvc.perform(get("{version}/models/{modelId}",
-                API_VERSION,
-                processModel.getId()))
+                            API_VERSION,
+                            processModel.getId()))
                 .andDo(print())
                 //then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.extensions.properties",
-                        allOf(hasEntry(equalTo("stringVariable"),
-                                allOf(hasEntry(equalTo("id"),
-                                        equalTo("stringVariable")),
-                                        hasEntry(equalTo("name"),
-                                                equalTo("stringVariable")),
-                                        hasEntry(equalTo("type"),
-                                                equalTo("string")),
-                                        hasEntry(equalTo("value"),
-                                                equalTo("stringVariable"))
-                                )),
-                                hasEntry(equalTo("integerVariable"),
-                                        allOf(hasEntry(equalTo("id"),
-                                                equalTo("integerVariable")),
-                                                hasEntry(equalTo("name"),
-                                                        equalTo("integerVariable")),
-                                                hasEntry(equalTo("type"),
-                                                        equalTo("integer")),
-                                                hasEntry(equalTo("value"),
-                                                        isIntegerEquals(15)))),
-                                hasEntry(equalTo("booleanVariable"),
-                                        allOf(hasEntry(equalTo("id"),
-                                                equalTo("booleanVariable")),
-                                                hasEntry(equalTo("name"),
-                                                        equalTo("booleanVariable")),
-                                                hasEntry(equalTo("type"),
-                                                        equalTo("boolean")),
-                                                hasEntry(equalTo("value"),
-                                                        isBooleanEquals(true)))),
-                                hasEntry(equalTo("dateVariable"),
-                                        allOf(hasEntry(equalTo("id"),
-                                                equalTo("dateVariable")),
-                                                hasEntry(equalTo("name"),
-                                                        equalTo("dateVariable")),
-                                                hasEntry(equalTo("type"),
-                                                        equalTo("date")),
-                                                hasEntry(equalTo("value"),
-                                                        isDateEquals(0)))),
-                                hasEntry(equalTo("jsonVariable"),
-                                        allOf(hasEntry(equalTo("id"),
-                                                equalTo("jsonVariable")),
-                                                hasEntry(equalTo("name"),
-                                                        equalTo("jsonVariable")),
-                                                hasEntry(equalTo("type"),
-                                                        equalTo("json")),
-                                                hasEntry(equalTo("value"),
-                                                        isJson(withJsonPath("json-field-name")))))
-                        )))
+                                    allOf(hasEntry(equalTo("stringVariable"),
+                                                   allOf(hasEntry(equalTo("id"),
+                                                                  equalTo("stringVariable")),
+                                                         hasEntry(equalTo("name"),
+                                                                  equalTo("stringVariable")),
+                                                         hasEntry(equalTo("type"),
+                                                                  equalTo("string")),
+                                                         hasEntry(equalTo("value"),
+                                                                  equalTo("stringVariable"))
+                                                   )),
+                                          hasEntry(equalTo("integerVariable"),
+                                                   allOf(hasEntry(equalTo("id"),
+                                                                  equalTo("integerVariable")),
+                                                         hasEntry(equalTo("name"),
+                                                                  equalTo("integerVariable")),
+                                                         hasEntry(equalTo("type"),
+                                                                  equalTo("integer")),
+                                                         hasEntry(equalTo("value"),
+                                                                  isIntegerEquals(15)))),
+                                          hasEntry(equalTo("booleanVariable"),
+                                                   allOf(hasEntry(equalTo("id"),
+                                                                  equalTo("booleanVariable")),
+                                                         hasEntry(equalTo("name"),
+                                                                  equalTo("booleanVariable")),
+                                                         hasEntry(equalTo("type"),
+                                                                  equalTo("boolean")),
+                                                         hasEntry(equalTo("value"),
+                                                                  isBooleanEquals(true)))),
+                                          hasEntry(equalTo("dateVariable"),
+                                                   allOf(hasEntry(equalTo("id"),
+                                                                  equalTo("dateVariable")),
+                                                         hasEntry(equalTo("name"),
+                                                                  equalTo("dateVariable")),
+                                                         hasEntry(equalTo("type"),
+                                                                  equalTo("date")),
+                                                         hasEntry(equalTo("value"),
+                                                                  isDateEquals(0)))),
+                                          hasEntry(equalTo("jsonVariable"),
+                                                   allOf(hasEntry(equalTo("id"),
+                                                                  equalTo("jsonVariable")),
+                                                         hasEntry(equalTo("name"),
+                                                                  equalTo("jsonVariable")),
+                                                         hasEntry(equalTo("type"),
+                                                                  equalTo("json")),
+                                                         hasEntry(equalTo("value"),
+                                                                  isJson(withJsonPath("json-field-name")))))
+                                    )))
                 .andExpect(jsonPath("$.extensions.mappings",
-                        hasEntry(equalTo("ServiceTask"),
-                                allOf(hasEntry(equalTo("inputs"),
-                                        allOf(hasEntry(equalTo("stringVariable"),
-                                                allOf(hasEntry(equalTo("type"),
-                                                        equalTo("value")),
-                                                        hasEntry(equalTo("value"),
-                                                                equalTo("stringVariable"))
-                                                )),
-                                                hasEntry(equalTo("integerVariable"),
-                                                        allOf(hasEntry(equalTo("type"),
-                                                                equalTo("value")),
-                                                                hasEntry(equalTo("value"),
-                                                                        equalTo("integerVariable"))
-                                                        )),
-                                                hasEntry(equalTo("booleanVariable"),
-                                                        allOf(hasEntry(equalTo("type"),
-                                                                equalTo("value")),
-                                                                hasEntry(equalTo("value"),
-                                                                        equalTo("booleanVariable"))
-                                                        )),
-                                                hasEntry(equalTo("dateVariable"),
-                                                        allOf(hasEntry(equalTo("type"),
-                                                                equalTo("value")),
-                                                                hasEntry(equalTo("value"),
-                                                                        equalTo("dateVariable"))
-                                                        )),
-                                                hasEntry(equalTo("jsonVariable"),
-                                                        allOf(hasEntry(equalTo("type"),
-                                                                equalTo("value")),
-                                                                hasEntry(equalTo("value"),
-                                                                        equalTo("jsonVariable"))
-                                                        )))),
-                                        hasEntry(equalTo("outputs"),
-                                                allOf(hasEntry(equalTo("stringVariable"),
-                                                        allOf(hasEntry(equalTo("type"),
-                                                                equalTo("value")),
-                                                                hasEntry(equalTo("value"),
-                                                                        equalTo("stringVariable"))
-                                                        )),
-                                                        hasEntry(equalTo("integerVariable"),
-                                                                allOf(hasEntry(equalTo("type"),
-                                                                        equalTo("value")),
-                                                                        hasEntry(equalTo("value"),
-                                                                                equalTo("integerVariable"))
-                                                                )),
-                                                        hasEntry(equalTo("booleanVariable"),
-                                                                allOf(hasEntry(equalTo("type"),
-                                                                        equalTo("value")),
-                                                                        hasEntry(equalTo("value"),
-                                                                                equalTo("booleanVariable"))
-                                                                )),
-                                                        hasEntry(equalTo("dateVariable"),
-                                                                allOf(hasEntry(equalTo("type"),
-                                                                        equalTo("value")),
-                                                                        hasEntry(equalTo("value"),
-                                                                                equalTo("dateVariable"))
-                                                                )),
-                                                        hasEntry(equalTo("jsonVariable"),
-                                                                allOf(hasEntry(equalTo("type"),
-                                                                        equalTo("value")),
-                                                                        hasEntry(equalTo("value"),
-                                                                                equalTo("jsonVariable"))
-                                                                ))))
-                                ))
+                                    hasEntry(equalTo("ServiceTask"),
+                                             allOf(hasEntry(equalTo("inputs"),
+                                                            allOf(hasEntry(equalTo("stringVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("stringVariable"))
+                                                                           )),
+                                                                  hasEntry(equalTo("integerVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("integerVariable"))
+                                                                           )),
+                                                                  hasEntry(equalTo("booleanVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("booleanVariable"))
+                                                                           )),
+                                                                  hasEntry(equalTo("dateVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("dateVariable"))
+                                                                           )),
+                                                                  hasEntry(equalTo("jsonVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("jsonVariable"))
+                                                                           )))),
+                                                   hasEntry(equalTo("outputs"),
+                                                            allOf(hasEntry(equalTo("stringVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("stringVariable"))
+                                                                           )),
+                                                                  hasEntry(equalTo("integerVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("integerVariable"))
+                                                                           )),
+                                                                  hasEntry(equalTo("booleanVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("booleanVariable"))
+                                                                           )),
+                                                                  hasEntry(equalTo("dateVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("dateVariable"))
+                                                                           )),
+                                                                  hasEntry(equalTo("jsonVariable"),
+                                                                           allOf(hasEntry(equalTo("type"),
+                                                                                          equalTo("value")),
+                                                                                 hasEntry(equalTo("value"),
+                                                                                          equalTo("jsonVariable"))
+                                                                           ))))
+                                             ))
                 ));
     }
 
@@ -417,10 +430,10 @@ public class ModelControllerIT {
 
         //when
         mockMvc.perform(post("{version}/projects/{projectId}/models",
-                API_VERSION,
-                parentProject.getId())
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
-                .content(mapper.writeValueAsString(processModel("process-model"))))
+                             API_VERSION,
+                             parentProject.getId())
+                                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                                .content(mapper.writeValueAsString(processModel("process-model"))))
                 .andExpect(status().isCreated());
     }
 
@@ -431,10 +444,10 @@ public class ModelControllerIT {
 
         //when
         mockMvc.perform(put("{version}/models/{modelId}",
-                API_VERSION,
-                processModel.getId())
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
-                .content(mapper.writeValueAsString(processModel("new-process-model"))))
+                            API_VERSION,
+                            processModel.getId())
+                                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                                .content(mapper.writeValueAsString(processModel("new-process-model"))))
                 .andExpect(status().isOk());
 
         //then
@@ -448,19 +461,19 @@ public class ModelControllerIT {
     public void testUpdateModelWithExtensions() throws Exception {
         //given
         ModelEntity processModel = processModelWithExtensions("process-model-extensions",
-                extensions("ServiceTask",
-                        "variable1"));
+                                                              extensions("ServiceTask",
+                                                                         "variable1"));
         modelRepository.createModel(processModel);
 
         ModelEntity newModel = processModelWithExtensions("process-model-extensions",
-                extensions("variable2",
-                        "variable3"));
+                                                          extensions("variable2",
+                                                                     "variable3"));
         //when
         mockMvc.perform(put("{version}/models/{modelId}",
-                API_VERSION,
-                processModel.getId())
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
-                .content(mapper.writeValueAsString(newModel)))
+                            API_VERSION,
+                            processModel.getId())
+                                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                                .content(mapper.writeValueAsString(newModel)))
                 .andExpect(status().isOk());
     }
 
@@ -471,8 +484,8 @@ public class ModelControllerIT {
 
         //when
         mockMvc.perform(delete("{version}/models/{modelId}",
-                API_VERSION,
-                processModel.getId()))
+                               API_VERSION,
+                               processModel.getId()))
                 .andExpect(status().isNoContent());
 
         //then
@@ -483,14 +496,14 @@ public class ModelControllerIT {
     public void testGetModelTypes() throws Exception {
 
         mockMvc.perform(get("{version}/model-types",
-                API_VERSION))
+                            API_VERSION))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.model-types",
-                        hasSize(2)))
+                                    hasSize(2)))
                 .andExpect(jsonPath("$._embedded.model-types[0].name",
-                        is(PROCESS)))
+                                    is(PROCESS)))
                 .andExpect(jsonPath("$._embedded.model-types[1].name",
-                        is(ConnectorModelType.NAME)));
+                                    is(ConnectorModelType.NAME)));
     }
 
     @Test
@@ -498,17 +511,20 @@ public class ModelControllerIT {
         // given
         byte[] validContent = resourceAsByteArray("process/x-19022.bpmn20.xml");
         MockMultipartFile file = new MockMultipartFile("file",
-                "process.xml",
-                CONTENT_TYPE_XML,
-                validContent);
-        Model processModel = modelRepository.createModel(processModel("Process-Model"));
+                                                       "process.xml",
+                                                       CONTENT_TYPE_XML,
+                                                       validContent);
+
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
 
         // when
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
-                        RepositoryRestConfig.API_VERSION,
-                        processModel.getId())
-                        .file(file))
+                                   RepositoryRestConfig.API_VERSION,
+                                   processModel.getId())
+                                 .file(file))
                 // then
                 .andExpect(status().isNoContent());
     }
@@ -518,63 +534,65 @@ public class ModelControllerIT {
 
         // given
         MockMultipartFile file = new MockMultipartFile("file",
-                "diagram.bpm",
-                CONTENT_TYPE_XML,
-                "BPMN diagram".getBytes());
-        Model processModel = modelRepository.createModel(processModel("Process-Model"));
+                                                       "diagram.bpm",
+                                                       CONTENT_TYPE_XML,
+                                                       "BPMN diagram".getBytes());
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
 
         // when
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
-                        RepositoryRestConfig.API_VERSION,
-                        processModel.getId())
-                        .file(file))
+                                   RepositoryRestConfig.API_VERSION,
+                                   processModel.getId())
+                                 .file(file))
                 // then
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    @Ignore
     public void validateProcessExtensionsWithValidContent() throws Exception {
 
         // given
-        byte[] validContent = resourceAsByteArray("process-extensions/valid-extensions.json");
-        MockMultipartFile file = new MockMultipartFile("file",
-                "extensions.json",
-                CONTENT_TYPE_JSON,
-                validContent);
-
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
-                new Extensions()));
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(
+                processModelWithExtensions(project,
+                                           "process-model",
+                                           new Extensions(),
+                                           resourceAsByteArray("process/x-19022.bpmn20.xml")));
+        MockMultipartFile file = multipartExtensionsFile(
+                processModel,
+                resourceAsByteArray("process-extensions/valid-extensions.json"));
 
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
-                RepositoryRestConfig.API_VERSION,
-                processModel.getId())
-                .file(file))
+                                  RepositoryRestConfig.API_VERSION,
+                                  processModel.getId())
+                                .file(file))
                 // then
                 .andExpect(status().isNoContent());
     }
 
     @Test
-    @Ignore
     public void validateProcessExtensionsWithValidContentAndNoValues() throws Exception {
 
         // given
-        byte[] validContent = resourceAsByteArray("process-extensions/valid-extensions-no-value.json");
-        MockMultipartFile file = new MockMultipartFile("file",
-                "extensions.json",
-                CONTENT_TYPE_JSON,
-                validContent);
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
+                                                                                    new Extensions(),
+                                                                                    resourceAsByteArray("process/x-19022.bpmn20.xml")));
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
-                new Extensions()));
+        MockMultipartFile file = multipartExtensionsFile(
+                processModel,
+                resourceAsByteArray("process-extensions/valid-extensions-no-value.json"));
 
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
-                RepositoryRestConfig.API_VERSION,
-                processModel.getId())
-                .file(file))
+                                  RepositoryRestConfig.API_VERSION,
+                                  processModel.getId())
+                                .file(file))
                 // then
                 .andExpect(status().isNoContent());
     }
@@ -583,19 +601,21 @@ public class ModelControllerIT {
     public void validateProcessExtensionsWithInvalidMappingContent() throws Exception {
 
         // given
-        byte[] invalidContent = resourceAsByteArray("process-extensions/invalid-mapping-extensions.json");
-        MockMultipartFile file = new MockMultipartFile("file",
-                "extensions.json",
-                CONTENT_TYPE_JSON,
-                invalidContent);
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(
+                processModelWithExtensions(project,
+                                           "process-model",
+                                           new Extensions(),
+                                           resourceAsByteArray("process/x-19022.bpmn20.xml")));
+        MockMultipartFile file = multipartExtensionsFile(
+                processModel,
+                resourceAsByteArray("process-extensions/invalid-mapping-extensions.json"));
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
-                new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
-                        RepositoryRestConfig.API_VERSION,
-                        processModel.getId()).file(file))
+                                   RepositoryRestConfig.API_VERSION,
+                                   processModel.getId()).file(file))
                 .andDo(print());
         // then
         resultActions.andExpect(status().isBadRequest());
@@ -608,11 +628,11 @@ public class ModelControllerIT {
         assertThat(semanticModelValidationException.getValidationErrors())
                 .hasSize(2)
                 .extracting(ModelValidationError::getProblem,
-                        ModelValidationError::getDescription)
+                            ModelValidationError::getDescription)
                 .containsOnly(tuple("inputds is not a valid enum value",
-                        "#/extensions/mappings/ServiceTask_06crg3b/inputds: inputds is not a valid enum value"),
-                        tuple("outputss is not a valid enum value",
-                                "#/extensions/mappings/ServiceTask_06crg3b/outputss: outputss is not a valid enum value"));
+                                    "#/extensions/mappings/ServiceTask_06crg3b/inputds: inputds is not a valid enum value"),
+                              tuple("outputss is not a valid enum value",
+                                    "#/extensions/mappings/ServiceTask_06crg3b/outputss: outputss is not a valid enum value"));
     }
 
     @Test
@@ -621,17 +641,19 @@ public class ModelControllerIT {
         // given
         byte[] invalidContent = resourceAsByteArray("process-extensions/invalid-string-variable-extensions.json");
         MockMultipartFile file = new MockMultipartFile("file",
-                "extensions.json",
-                CONTENT_TYPE_JSON,
-                invalidContent);
+                                                       "extensions.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
-                new Extensions()));
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
+                                                                                    new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
-                        RepositoryRestConfig.API_VERSION,
-                        processModel.getId()).file(file))
+                                   RepositoryRestConfig.API_VERSION,
+                                   processModel.getId()).file(file))
                 .andDo(print());
         // then
         resultActions.andExpect(status().isBadRequest());
@@ -642,9 +664,9 @@ public class ModelControllerIT {
         SemanticModelValidationException semanticModelValidationException = (SemanticModelValidationException) resolvedException;
         assertThat(semanticModelValidationException.getValidationErrors())
                 .extracting(ModelValidationError::getProblem,
-                        ModelValidationError::getDescription)
+                            ModelValidationError::getDescription)
                 .containsExactly(tuple("expected type: String, found: Integer",
-                        "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: String, found: Integer"));
+                                       "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: String, found: Integer"));
     }
 
     @Test
@@ -653,17 +675,19 @@ public class ModelControllerIT {
         // given
         byte[] invalidContent = resourceAsByteArray("process-extensions/invalid-integer-variable-extensions.json");
         MockMultipartFile file = new MockMultipartFile("file",
-                "extensions.json",
-                CONTENT_TYPE_JSON,
-                invalidContent);
+                                                       "extensions.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
-                new Extensions()));
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
+                                                                                    new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
-                        RepositoryRestConfig.API_VERSION,
-                        processModel.getId()).file(file))
+                                   RepositoryRestConfig.API_VERSION,
+                                   processModel.getId()).file(file))
                 .andDo(print());
         // then
         resultActions.andExpect(status().isBadRequest());
@@ -674,9 +698,9 @@ public class ModelControllerIT {
         SemanticModelValidationException semanticModelValidationException = (SemanticModelValidationException) resolvedException;
         assertThat(semanticModelValidationException.getValidationErrors())
                 .extracting(ModelValidationError::getProblem,
-                        ModelValidationError::getDescription)
+                            ModelValidationError::getDescription)
                 .containsExactly(tuple("expected type: Number, found: String",
-                        "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: Number, found: String"));
+                                       "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: Number, found: String"));
     }
 
     @Test
@@ -685,17 +709,19 @@ public class ModelControllerIT {
         // given
         byte[] invalidContent = resourceAsByteArray("process-extensions/invalid-boolean-variable-extensions.json");
         MockMultipartFile file = new MockMultipartFile("file",
-                "extensions.json",
-                CONTENT_TYPE_JSON,
-                invalidContent);
+                                                       "extensions.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
-                new Extensions()));
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
+                                                                                    new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
-                        RepositoryRestConfig.API_VERSION,
-                        processModel.getId()).file(file))
+                                   RepositoryRestConfig.API_VERSION,
+                                   processModel.getId()).file(file))
                 .andDo(print());
         // then
         resultActions.andExpect(status().isBadRequest());
@@ -706,9 +732,9 @@ public class ModelControllerIT {
         SemanticModelValidationException semanticModelValidationException = (SemanticModelValidationException) resolvedException;
         assertThat(semanticModelValidationException.getValidationErrors())
                 .extracting(ModelValidationError::getProblem,
-                        ModelValidationError::getDescription)
+                            ModelValidationError::getDescription)
                 .containsExactly(tuple("expected type: Boolean, found: Integer",
-                        "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: Boolean, found: Integer"));
+                                       "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: Boolean, found: Integer"));
     }
 
     @Test
@@ -717,17 +743,19 @@ public class ModelControllerIT {
         // given
         byte[] invalidContent = resourceAsByteArray("process-extensions/invalid-object-variable-extensions.json");
         MockMultipartFile file = new MockMultipartFile("file",
-                "extensions.json",
-                CONTENT_TYPE_JSON,
-                invalidContent);
+                                                       "extensions.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
-                new Extensions()));
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
+                                                                                    new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
-                        RepositoryRestConfig.API_VERSION,
-                        processModel.getId()).file(file))
+                                   RepositoryRestConfig.API_VERSION,
+                                   processModel.getId()).file(file))
                 .andDo(print());
         // then
         resultActions.andExpect(status().isBadRequest());
@@ -738,9 +766,9 @@ public class ModelControllerIT {
         SemanticModelValidationException semanticModelValidationException = (SemanticModelValidationException) resolvedException;
         assertThat(semanticModelValidationException.getValidationErrors())
                 .extracting(ModelValidationError::getProblem,
-                        ModelValidationError::getDescription)
+                            ModelValidationError::getDescription)
                 .containsExactly(tuple("expected type: JSONObject, found: Integer",
-                        "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: JSONObject, found: Integer"));
+                                       "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: JSONObject, found: Integer"));
     }
 
     @Test
@@ -749,17 +777,19 @@ public class ModelControllerIT {
         // given
         byte[] invalidContent = resourceAsByteArray("process-extensions/invalid-date-variable-extensions.json");
         MockMultipartFile file = new MockMultipartFile("file",
-                "extensions.json",
-                CONTENT_TYPE_JSON,
-                invalidContent);
+                                                       "extensions.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
-                new Extensions()));
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
+                                                                                    new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
                 .perform(multipart("{version}/models/{model_id}/validate",
-                        RepositoryRestConfig.API_VERSION,
-                        processModel.getId()).file(file))
+                                   RepositoryRestConfig.API_VERSION,
+                                   processModel.getId()).file(file))
                 .andDo(print());
         // then
         resultActions.andExpect(status().isBadRequest());
@@ -770,12 +800,12 @@ public class ModelControllerIT {
         SemanticModelValidationException semanticModelValidationException = (SemanticModelValidationException) resolvedException;
         assertThat(semanticModelValidationException.getValidationErrors())
                 .extracting(ModelValidationError::getProblem,
-                        ModelValidationError::getDescription)
+                            ModelValidationError::getDescription)
                 .containsExactly(
                         tuple("expected type: String, found: Integer",
-                                "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: String, found: Integer"),
+                              "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c68/value: expected type: String, found: Integer"),
                         tuple("string [aloha] does not match pattern ^[0-9]{4}-(((0[13578]|(10|12))-(0[1-9]|[1-2][0-9]|3[0-1]))|(02-(0[1-9]|[1-2][0-9]))|((0[469]|11)-(0[1-9]|[1-2][0-9]|30)))$",
-                                "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c64/value: string [aloha] does not match pattern ^[0-9]{4}-(((0[13578]|(10|12))-(0[1-9]|[1-2][0-9]|3[0-1]))|(02-(0[1-9]|[1-2][0-9]))|((0[469]|11)-(0[1-9]|[1-2][0-9]|30)))$")
+                              "#/extensions/properties/c297ec88-0ecf-4841-9b0f-2ae814957c64/value: string [aloha] does not match pattern ^[0-9]{4}-(((0[13578]|(10|12))-(0[1-9]|[1-2][0-9]|3[0-1]))|(02-(0[1-9]|[1-2][0-9]))|((0[469]|11)-(0[1-9]|[1-2][0-9]|30)))$")
                 );
     }
 
@@ -783,14 +813,14 @@ public class ModelControllerIT {
     public void validateModelThatNotExistsShouldThrowException() throws Exception {
         // given
         MockMultipartFile file = new MockMultipartFile("file",
-                "diagram.bpm",
-                "text/plain",
-                "BPMN diagram".getBytes());
+                                                       "diagram.bpm",
+                                                       "text/plain",
+                                                       "BPMN diagram".getBytes());
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
-                RepositoryRestConfig.API_VERSION,
-                "model_id")
-                .file(file))
+                                  RepositoryRestConfig.API_VERSION,
+                                  "model_id")
+                                .file(file))
                 // then
                 .andExpect(status().isNotFound());
     }
@@ -800,16 +830,19 @@ public class ModelControllerIT {
 
         // given
         MockMultipartFile file = new MockMultipartFile("file",
-                "diagram.bpmn20.xml",
-                "text/plain",
-                "BPMN diagram".getBytes());
-        Model processModel = modelRepository.createModel(processModel("Process-Model"));
+                                                       "diagram.bpmn20.xml",
+                                                       "text/plain",
+                                                       "BPMN diagram".getBytes());
+
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
 
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
-                API_VERSION,
-                processModel.getId())
-                .file(file))
+                                  API_VERSION,
+                                  processModel.getId())
+                                .file(file))
                 // then
                 .andExpect(status().isBadRequest());
     }
@@ -819,16 +852,19 @@ public class ModelControllerIT {
         // given
         byte[] validContent = resourceAsByteArray("connector/connector-simple.json");
         MockMultipartFile file = new MockMultipartFile("file",
-                "connector-simple.json",
-                CONTENT_TYPE_JSON,
-                validContent);
-        Model connectorModel = modelRepository.createModel(connectorModel("Connector-Model"));
+                                                       "connector-simple.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       validContent);
+
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model connectorModel = modelRepository.createModel(connectorModel(project,
+                                                                          "connector-model"));
 
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
-                API_VERSION,
-                connectorModel.getId())
-                .file(file))
+                                  API_VERSION,
+                                  connectorModel.getId())
+                                .file(file))
                 // then
                 .andExpect(status().isNoContent());
     }
@@ -838,16 +874,19 @@ public class ModelControllerIT {
         // given
         byte[] validContent = resourceAsByteArray("connector/connector-template.json");
         MockMultipartFile file = new MockMultipartFile("file",
-                "connector-template.json",
-                CONTENT_TYPE_JSON,
-                validContent);
-        Model connectorModel = modelRepository.createModel(connectorModel("Connector-Model"));
+                                                       "connector-template.json",
+                                                       CONTENT_TYPE_JSON,
+                                                       validContent);
+
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model connectorModel = modelRepository.createModel(connectorModel(project,
+                                                                          "connector-model"));
 
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
-                API_VERSION,
-                connectorModel.getId())
-                .file(file))
+                                  API_VERSION,
+                                  connectorModel.getId())
+                                .file(file))
                 // then
                 .andExpect(status().isNoContent());
     }
@@ -856,12 +895,12 @@ public class ModelControllerIT {
     public void testExportModel() throws Exception {
         //GIVEN
         Model processModel = modelRepository.createModel(processModelWithContent("process_model_id",
-                "Process Model Content"));
+                                                                                 "Process Model Content"));
         // WHEN
         MvcResult response = mockMvc.perform(
                 get("{version}/models/{modelId}/export",
-                        API_VERSION,
-                        processModel.getId()))
+                    API_VERSION,
+                    processModel.getId()))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -878,7 +917,7 @@ public class ModelControllerIT {
         // WHEN
         mockMvc.perform(
                 get("{version}/models/not_existing_model/export",
-                        API_VERSION))
+                    API_VERSION))
                 // THEN
                 .andExpect(status().isNotFound())
                 .andReturn();
@@ -890,18 +929,18 @@ public class ModelControllerIT {
         Project parentProject = projectRepository.createProject(project("parent-project"));
 
         MockMultipartFile zipFile = new MockMultipartFile("file",
-                "x-19022.bpmn20.xml",
-                "project/xml",
-                resourceAsByteArray("process/x-19022.bpmn20.xml"));
+                                                          "x-19022.bpmn20.xml",
+                                                          "project/xml",
+                                                          resourceAsByteArray("process/x-19022.bpmn20.xml"));
 
         // WHEN
         mockMvc.perform(multipart("{version}/projects/{projectId}/models/import",
-                API_VERSION,
-                parentProject.getId())
-                .file(zipFile)
-                .param("type",
-                        PROCESS)
-                .accept(APPLICATION_JSON_VALUE))
+                                  API_VERSION,
+                                  parentProject.getId())
+                                .file(zipFile)
+                                .param("type",
+                                       PROCESS)
+                                .accept(APPLICATION_JSON_VALUE))
                 .andDo(print())
                 // THEN
                 .andExpect(status().isCreated());
@@ -914,18 +953,18 @@ public class ModelControllerIT {
         projectRepository.createProject(parentProject);
 
         MockMultipartFile zipFile = new MockMultipartFile("file",
-                "x-19022",
-                "project/xml",
-                resourceAsByteArray("process/x-19022.bpmn20.xml"));
+                                                          "x-19022",
+                                                          "project/xml",
+                                                          resourceAsByteArray("process/x-19022.bpmn20.xml"));
 
         // WHEN
         mockMvc.perform(multipart("{version}/projects/{projectId}/models/import",
-                API_VERSION,
-                parentProject.getId())
-                .file(zipFile)
-                .param("type",
-                        PROCESS)
-                .accept(APPLICATION_JSON_VALUE))
+                                  API_VERSION,
+                                  parentProject.getId())
+                                .file(zipFile)
+                                .param("type",
+                                       PROCESS)
+                                .accept(APPLICATION_JSON_VALUE))
                 // THEN
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -939,17 +978,17 @@ public class ModelControllerIT {
         projectRepository.createProject(parentProject);
 
         MockMultipartFile zipFile = new MockMultipartFile("file",
-                "x-19022.xml",
-                "project/xml",
-                resourceAsByteArray("process/x-19022.bpmn20.xml"));
+                                                          "x-19022.xml",
+                                                          "project/xml",
+                                                          resourceAsByteArray("process/x-19022.bpmn20.xml"));
 
         // WHEN
         mockMvc.perform(multipart("{version}/projects/{projectId}/models/import",
-                API_VERSION,
-                parentProject.getId())
-                .file(zipFile)
-                .param("type",
-                        "WRONG_TYPE"))
+                                  API_VERSION,
+                                  parentProject.getId())
+                                .file(zipFile)
+                                .param("type",
+                                       "WRONG_TYPE"))
                 // THEN
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -960,16 +999,16 @@ public class ModelControllerIT {
     public void testImportModelProjectNotFound() throws Exception {
         //GIVEN
         MockMultipartFile zipFile = new MockMultipartFile("file",
-                "x-19022.xml",
-                "project/xml",
-                resourceAsByteArray("process/x-19022.bpmn20.xml"));
+                                                          "x-19022.xml",
+                                                          "project/xml",
+                                                          resourceAsByteArray("process/x-19022.bpmn20.xml"));
 
         // WHEN
         mockMvc.perform(multipart("{version}/projects/not_existing_project/models/import",
-                API_VERSION)
-                .file(zipFile)
-                .param("type",
-                        PROCESS))
+                                  API_VERSION)
+                                .file(zipFile)
+                                .param("type",
+                                       PROCESS))
                 // THEN
                 .andDo(print())
                 .andExpect(status().isNotFound());
@@ -982,22 +1021,22 @@ public class ModelControllerIT {
 
         // WHEN
         mockMvc.perform(putMultipart("{version}/models/{modelId}/content",
-                API_VERSION,
-                connectorModel.getId())
-                .file("file",
-                        "connector-template.json",
-                        "application/json",
-                        resourceAsByteArray("connector/connector-template.json")))
+                                     API_VERSION,
+                                     connectorModel.getId())
+                                .file("file",
+                                      "connector-template.json",
+                                      "application/json",
+                                      resourceAsByteArray("connector/connector-template.json")))
                 .andExpect(status().isNoContent());
 
         // THEN
         mockMvc.perform(get("{version}/models/{modelId}",
-                API_VERSION,
-                connectorModel.getId()))
+                            API_VERSION,
+                            connectorModel.getId()))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.template",
-                        is("ConnectorTemplate")));
+                                    is("ConnectorTemplate")));
     }
 
     @Test
@@ -1007,18 +1046,18 @@ public class ModelControllerIT {
 
         // WHEN
         mockMvc.perform(putMultipart("{version}/models/{modelId}/content",
-                API_VERSION,
-                connectorModel.getId())
-                .file("file",
-                        "connector-simple.json",
-                        "application/json",
-                        resourceAsByteArray("connector/connector-simple.json")))
+                                     API_VERSION,
+                                     connectorModel.getId())
+                                .file("file",
+                                      "connector-simple.json",
+                                      "application/json",
+                                      resourceAsByteArray("connector/connector-simple.json")))
                 .andExpect(status().isNoContent());
 
         // THEN
         mockMvc.perform(get("{version}/models/{modelId}",
-                API_VERSION,
-                connectorModel.getId()))
+                            API_VERSION,
+                            connectorModel.getId()))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.template").doesNotExist());

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelValidationControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelValidationControllerIT.java
@@ -16,6 +16,7 @@
 
 package org.activiti.cloud.services.organization.rest.controller;
 
+import org.activiti.cloud.organization.api.ConnectorModelType;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.api.ModelValidationError;
 import org.activiti.cloud.organization.api.ProcessModelType;
@@ -43,6 +44,7 @@ import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_T
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_XML;
 import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteArray;
 import static org.activiti.cloud.services.organization.asserts.AssertResponse.assertThatResponse;
+import static org.activiti.cloud.services.organization.mock.MockFactory.connectorFileContent;
 import static org.activiti.cloud.services.organization.mock.MockFactory.connectorModel;
 import static org.activiti.cloud.services.organization.mock.MockFactory.multipartExtensionsFile;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processFileContent;
@@ -82,6 +84,9 @@ public class ModelValidationControllerIT {
     @Autowired
     private ProcessModelType processModelType;
 
+    @Autowired
+    private ConnectorModelType connectorModelType;
+
     private MockMvc mockMvc;
 
     @Before
@@ -97,7 +102,9 @@ public class ModelValidationControllerIT {
                                                        "process.xml",
                                                        CONTENT_TYPE_XML,
                                                        validContent);
-        Model processModel = modelRepository.createModel(processModel("Process-Model"));
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
 
         // when
         mockMvc
@@ -117,7 +124,10 @@ public class ModelValidationControllerIT {
                                                        "diagram.bpm",
                                                        CONTENT_TYPE_XML,
                                                        "BPMN diagram".getBytes());
-        Model processModel = modelRepository.createModel(processModel("Process-Model"));
+
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
 
         // when
         mockMvc
@@ -133,8 +143,10 @@ public class ModelValidationControllerIT {
     public void validateProcessExtensionsWithValidContent() throws Exception {
 
         // given
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
         Model processModel = modelRepository.createModel(
-                processModelWithExtensions("Process-Model",
+                processModelWithExtensions(project,
+                                           "process-model",
                                            new Extensions(),
                                            resourceAsByteArray("process/RankMovie.bpmn20.xml")));
         MockMultipartFile file = multipartExtensionsFile(
@@ -155,8 +167,10 @@ public class ModelValidationControllerIT {
     public void validateProcessExtensionsWithValidContentAndNoDefaultValues() throws Exception {
 
         // given
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
         Model processModel = modelRepository.createModel(
-                processModelWithExtensions("Process-Model",
+                processModelWithExtensions(project,
+                                           "process-model",
                                            new Extensions(),
                                            resourceAsByteArray("process/RankMovie.bpmn20.xml")));
         MockMultipartFile file = multipartExtensionsFile(
@@ -182,7 +196,9 @@ public class ModelValidationControllerIT {
                                                        CONTENT_TYPE_JSON,
                                                        invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
                                                                                     new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
@@ -219,7 +235,9 @@ public class ModelValidationControllerIT {
                                                        CONTENT_TYPE_JSON,
                                                        invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
                                                                                     new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
@@ -251,7 +269,9 @@ public class ModelValidationControllerIT {
                                                        CONTENT_TYPE_JSON,
                                                        invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "Process-Model",
                                                                                     new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
@@ -283,7 +303,9 @@ public class ModelValidationControllerIT {
                                                        CONTENT_TYPE_JSON,
                                                        invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
                                                                                     new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
@@ -315,7 +337,9 @@ public class ModelValidationControllerIT {
                                                        CONTENT_TYPE_JSON,
                                                        invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
                                                                                     new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
@@ -347,7 +371,9 @@ public class ModelValidationControllerIT {
                                                        CONTENT_TYPE_JSON,
                                                        invalidContent);
 
-        Model processModel = modelRepository.createModel(processModelWithExtensions("Process-Model",
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModelWithExtensions(project,
+                                                                                    "process-model",
                                                                                     new Extensions()));
         // when
         final ResultActions resultActions = mockMvc
@@ -397,7 +423,10 @@ public class ModelValidationControllerIT {
                                                        "diagram.bpmn20.xml",
                                                        "text/plain",
                                                        "BPMN diagram".getBytes());
-        Model processModel = modelRepository.createModel(processModel("Process-Model"));
+
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
 
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
@@ -416,7 +445,9 @@ public class ModelValidationControllerIT {
                                                        "connector-simple.json",
                                                        CONTENT_TYPE_JSON,
                                                        validContent);
-        Model connectorModel = modelRepository.createModel(connectorModel("Connector-Model"));
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model connectorModel = modelRepository.createModel(connectorModel(project,
+                                                                          "connector-model"));
 
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
@@ -435,7 +466,10 @@ public class ModelValidationControllerIT {
                                                        "connector-template.json",
                                                        CONTENT_TYPE_JSON,
                                                        validContent);
-        Model connectorModel = modelRepository.createModel(connectorModel("Connector-Model"));
+
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model connectorModel = modelRepository.createModel(connectorModel(project,
+                                                                          "connector-model"));
 
         // when
         mockMvc.perform(multipart("{version}/models/{model_id}/validate",
@@ -495,6 +529,39 @@ public class ModelValidationControllerIT {
                 .hasValidationErrorMessages(
                         "The extensions for process 'process-" + processModel.getId() +
                                 "' contains mappings for an unknown task 'unknown-task'");
+    }
+
+    @Test
+    public void validateProcessExtensionsWithUnknownConnectorParameterMapping() throws Exception {
+        // given
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("movies"));
+        Model processModel = modelService.importModel(project,
+                                                      processModelType,
+                                                      processFileContent("RankMovie",
+                                                                         resourceAsByteArray("process/RankMovie.bpmn20.xml")));
+        modelService.importModel(project,
+                                 connectorModelType,
+                                 connectorFileContent("movies",
+                                                      resourceAsByteArray("connector/movies.json")));
+
+        MockMultipartFile file = multipartExtensionsFile(
+                processModel,
+                resourceAsByteArray("process-extensions/RankMovie-extensions-unknown-connector-parameter.json"));
+
+        assertThatResponse(
+                mockMvc.perform(multipart("{version}/models/{model_id}/validate",
+                                          API_VERSION,
+                                          processModel.getId())
+                                        .file(file))
+                        .andExpect(status().isBadRequest())
+                        .andReturn())
+                .isSemanticValidationException()
+                .hasValidationErrorMessages(
+                        "The extensions for process 'process-" + processModel.getId() +
+                                "' contains mappings for an unknown inputs connector parameter name 'unknown-input-parameter'",
+                        "The extensions for process 'process-" + processModel.getId() +
+                                "' contains mappings for an unknown outputs connector parameter name 'unknown-output-parameter'"
+                );
     }
 
     @Test

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ProjectControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ProjectControllerIT.java
@@ -49,9 +49,12 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteArray;
 import static org.activiti.cloud.services.organization.mock.MockFactory.connectorModel;
 import static org.activiti.cloud.services.organization.mock.MockFactory.extensions;
+import static org.activiti.cloud.services.organization.mock.MockFactory.inputsMappings;
+import static org.activiti.cloud.services.organization.mock.MockFactory.outputsMappings;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processFileContent;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModelWithContent;
 import static org.activiti.cloud.services.organization.mock.MockFactory.processModelWithExtensions;
+import static org.activiti.cloud.services.organization.mock.MockFactory.processVariables;
 import static org.activiti.cloud.services.organization.mock.MockFactory.project;
 import static org.activiti.cloud.services.organization.mock.MockFactory.projectWithDescription;
 import static org.activiti.cloud.services.organization.rest.config.RepositoryRestConfig.API_VERSION;
@@ -258,8 +261,10 @@ public class ProjectControllerIT {
         modelRepository.updateModel(processModel,
                                     processModelWithExtensions("process-model",
                                                                extensions("Task_1spvopd",
-                                                                          "movieToRank",
-                                                                          "movieDesc")));
+                                                                          processVariables("movieName",
+                                                                                           "movieDescription"),
+                                                                          inputsMappings("movieName"),
+                                                                          outputsMappings("movieDescription"))));
 
         // WHEN
         MvcResult response = mockMvc.perform(
@@ -288,16 +293,14 @@ public class ProjectControllerIT {
                                           jsonContent -> jsonContent
                                                   .node("name").isEqualTo("process-model")
                                                   .node("type").isEqualTo("PROCESS")
-                                                  .node("extensions.properties").matches(allOf(hasKey("movieToRank"),
-                                                                                               hasKey("movieDesc")))
+                                                  .node("extensions.properties").matches(allOf(hasKey("movieName"),
+                                                                                               hasKey("movieDescription")))
                                                   .node("extensions.mappings").matches(
                                                           hasEntry(equalTo("Task_1spvopd"),
                                                                    allOf(hasEntry(equalTo("inputs"),
-                                                                                  allOf(hasKey("movieToRank"),
-                                                                                        hasKey("movieDesc"))),
+                                                                                  hasKey("movieName")),
                                                                          hasEntry(equalTo("outputs"),
-                                                                                  allOf(hasKey("movieToRank"),
-                                                                                        hasKey("movieDesc"))))))
+                                                                                  hasKey("movieDescription")))))
 
                 );
     }
@@ -379,8 +382,8 @@ public class ProjectControllerIT {
                             ModelValidationError::getDescription,
                             ModelValidationError::getValidatorSetName)
                 .contains(tuple("Invalid service implementation",
-                                    "Invalid service implementation on service 'ServiceTask_1qr4ad0'",
-                                    "BPMN service task validator"));
+                                "Invalid service implementation on service 'ServiceTask_1qr4ad0'",
+                                "BPMN service task validator"));
     }
 
     @Test
@@ -408,11 +411,11 @@ public class ProjectControllerIT {
                             ModelValidationError::getDescription,
                             ModelValidationError::getValidatorSetName)
                 .contains(tuple("activiti-servicetask-missing-implementation",
-                                    "One of the attributes 'implementation', 'class', 'delegateExpression', 'type', 'operation', or 'expression' is mandatory on serviceTask.",
-                                    "activiti-executable-process"),
-                              tuple("Invalid service implementation",
-                                    "Invalid service implementation on service 'ServiceTask_1qr4ad0'",
-                                    "BPMN service task validator"));
+                                "One of the attributes 'implementation', 'class', 'delegateExpression', 'type', 'operation', or 'expression' is mandatory on serviceTask.",
+                                "activiti-executable-process"),
+                          tuple("Invalid service implementation",
+                                "Invalid service implementation on service 'ServiceTask_1qr4ad0'",
+                                "BPMN service task validator"));
     }
 
     @Test

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-connector-parameter.json
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-connector-parameter.json
@@ -1,0 +1,43 @@
+{
+    "id": "process-98ff0720-f94b-40a7-84f6-a9c8fab70568",
+    "type": "PROCESS",
+    "name": "RankMovie",
+    "extensions": {
+        "properties": {
+            "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
+                "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
+                "name": "movieToRank",
+                "type": "string",
+                "required": true
+            },
+            "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
+                "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
+                "name": "movieDesc",
+                "type": "string",
+                "required": false
+            },
+            "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
+                "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
+                "name": "rating",
+                "type": "integer",
+                "required": false
+            }
+        },
+        "mappings": {
+            "Task_1spvopd": {
+                "inputs": {
+                    "unknown-input-parameter": {
+                        "type": "variable",
+                        "value": "movieToRank"
+                    }
+                },
+                "outputs": {
+                    "movieDesc": {
+                        "type": "variable",
+                        "value": "unknown-output-parameter"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process-extensions/valid-extensions.json
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process-extensions/valid-extensions.json
@@ -1,26 +1,6 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "mappings": {
-      "ServiceTask_06crg3b": {
-        "inputs": {
-          "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
-            "type": "variable",
-            "value": "name1"
-          },
-          "aa4a9329-71be-4889-8265-398b68536d4a": {
-            "type": "variable",
-            "value": "name2"
-          }
-        },
-        "outputs": {
-          "7d74c83b-6d52-48db-a816-1d4992a40947": {
-            "type": "value",
-            "value": "test"
-          }
-        }
-      }
-    },
     "constants": {
       "ServiceTask_06crg3b": {
         "my-custom-variable": {

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/BpmnProcessModelContent.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/BpmnProcessModelContent.java
@@ -66,19 +66,18 @@ public class BpmnProcessModelContent implements ModelContent {
         return null;
     }
 
-    public Set<String> findAllTaskIds() {
-        return findAllActivityIds(Task.class,
-                                  CallActivity.class);
+    public Set<Activity> findAllActivities() {
+        return findAllActivities(Task.class,
+                                 CallActivity.class);
     }
 
-    public Set<String> findAllActivityIds(Class<? extends Activity>... activityTypes) {
+    public Set<Activity> findAllActivities(Class<? extends Activity>... activityTypes) {
         return bpmnModel.getProcesses()
                 .stream()
                 .flatMap(process -> Arrays.stream(activityTypes)
                         .map(process::findFlowElementsOfType)
                         .flatMap(List::stream)
                 )
-                .map(Activity::getId)
                 .collect(Collectors.toSet());
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ConnectorActionParameter.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ConnectorActionParameter.java
@@ -16,25 +16,18 @@
 
 package org.activiti.cloud.services.organization.converter;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
 /**
- * Implementation dependency for the {@link ConnectorModelContent}
+ * ConnectorActionParameter POJO
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(NON_NULL)
-public class ConnectorModelAction {
+public class ConnectorActionParameter {
 
     private String id;
+
+    private String type;
+
     private String name;
+
     private String description;
-
-    private ConnectorActionParameter[] inputs;
-
-    private ConnectorActionParameter[] outputs;
 
     public String getId() {
         return id;
@@ -42,6 +35,14 @@ public class ConnectorModelAction {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     public String getName() {
@@ -58,21 +59,5 @@ public class ConnectorModelAction {
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public ConnectorActionParameter[] getInputs() {
-        return inputs;
-    }
-
-    public void setInputs(ConnectorActionParameter[] inputs) {
-        this.inputs = inputs;
-    }
-
-    public ConnectorActionParameter[] getOutputs() {
-        return outputs;
-    }
-
-    public void setOutputs(ConnectorActionParameter[] outputs) {
-        this.outputs = outputs;
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ConnectorModelContent.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/ConnectorModelContent.java
@@ -33,6 +33,8 @@ public class ConnectorModelContent implements ModelContent {
 
     private String id;
 
+    private String name;
+
     private String template;
 
     private Map<String, ConnectorModelAction> actions;
@@ -44,6 +46,14 @@ public class ConnectorModelContent implements ModelContent {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     @Override

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
@@ -36,6 +36,7 @@ import org.activiti.cloud.organization.core.error.UnknownModelTypeException;
 import org.activiti.cloud.organization.repository.ModelRepository;
 import org.activiti.cloud.services.common.file.FileContent;
 import org.activiti.cloud.services.organization.validation.ModelValidationContext;
+import org.activiti.cloud.services.organization.validation.ProjectValidationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -294,7 +295,9 @@ public class ModelService {
         validateModelContent(model.getType(),
                              fileContent.getFileContent(),
                              fileContent.getContentType(),
-                             new ModelValidationContext(model));
+                             Optional.ofNullable(model.getProject())
+                                     .map(this::createProjectValidationContext)
+                                     .orElseGet(() -> createModelValidationContext(model)));
     }
 
     public void validateModelContent(Model model,
@@ -314,6 +317,14 @@ public class ModelService {
                                                contentType)
                 .ifPresent(modelValidator -> modelValidator.validateModelContent(modelContent,
                                                                                  validationContext));
+    }
+
+    private ValidationContext createProjectValidationContext(Project project) {
+        return new ProjectValidationContext(getAllModels(project));
+    }
+
+    private ValidationContext createModelValidationContext(Model model) {
+        return new ModelValidationContext(model);
     }
 
     private ModelType findModelType(Model model) {


### PR DESCRIPTION
- add validation for connector parameter names
- use project validation context also when validating only a model
- update tests and add integration for invalid connector parameter name

https://github.com/Activiti/Activiti/issues/2889
https://issues.alfresco.com/jira/browse/ACTIVITI-3398
https://issues.alfresco.com/jira/browse/ACTIVITI-3632