### PR TITLE
fix(build): removed spring-cloud-stream dependencies

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/pom.xml
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/pom.xml
@@ -110,6 +110,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream-test-support</artifactId>
+      <scope>test</scope>
+    </dependency>    
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
       <scope>test</scope>

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/pom.xml
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/pom.xml
@@ -140,11 +140,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-stream-test-support</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.activiti.cloud.modeling</groupId>
       <artifactId>activiti-cloud-services-org-jpa</artifactId>
       <scope>test</scope>

--- a/activiti-cloud-starter-org/pom.xml
+++ b/activiti-cloud-starter-org/pom.xml
@@ -44,10 +44,6 @@
       <artifactId>activiti-cloud-services-swagger</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-stream</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>


### PR DESCRIPTION
This PR removes unnecessary `spring-cloud-stream` dependency from `activiti-cloud-org-starter` because modeling app does have and use cloud stream messaging.