### PR TITLE
AAE-698 Allow to set the name when importing a project

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/main/java/org/activiti/cloud/services/organization/rest/api/ProjectRestApi.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/main/java/org/activiti/cloud/services/organization/rest/api/ProjectRestApi.java
@@ -76,6 +76,8 @@ public interface ProjectRestApi {
                     "but not download the file.";
 
     String PROJECT_NAME_PARAM_DESCR = "The name or part of the name to filter projects";
+    
+    String PROJECT_NAME_OVERRIDE_DESCR = "The name of the project that will override the current name of the project in the zip file";
 
     String UPLOAD_FILE_PARAM_NAME = "file";
 
@@ -140,7 +142,11 @@ public interface ProjectRestApi {
     @ResponseStatus(CREATED)
     Resource<Project> importProject(
             @ApiParam(IMPORT_PROJECT_FILE_PARAM_DESCR)
-            @RequestParam(UPLOAD_FILE_PARAM_NAME) MultipartFile file) throws IOException;
+            @RequestParam(UPLOAD_FILE_PARAM_NAME) MultipartFile file,
+            @ApiParam(PROJECT_NAME_OVERRIDE_DESCR)
+            @RequestParam(
+                    name = PROJECT_NAME_PARAM_NAME,
+                    required = false) String name) throws IOException;
 
     @ApiOperation(
             tags = PROJECTS,

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/main/java/org/activiti/cloud/services/organization/rest/controller/ProjectController.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/main/java/org/activiti/cloud/services/organization/rest/controller/ProjectController.java
@@ -103,8 +103,10 @@ public class ProjectController implements ProjectRestApi {
 
     @Override
     public Resource<Project> importProject(
-            @RequestParam(UPLOAD_FILE_PARAM_NAME) MultipartFile file) throws IOException {
-        return resourceAssembler.toResource(projectService.importProject(file));
+            @RequestParam(UPLOAD_FILE_PARAM_NAME) MultipartFile file,
+            @RequestParam(name = PROJECT_NAME_PARAM_NAME,
+                          required = false) String name) throws IOException {
+        return resourceAssembler.toResource(projectService.importProject(file, name));
     }
 
     @Override

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ProjectControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ProjectControllerIT.java
@@ -725,4 +725,48 @@ public class ProjectControllerIT {
                 .andExpect(status().isBadRequest())
                 .andExpect(status().reason(containsString("Error importing model : Error reading XML")));
     }
+    
+    @Test
+    public void should_returnStatusCreatedAndGivenName_when_importingProjectWithNameProvided() throws Exception {
+        MockMultipartFile zipFile = new MockMultipartFile("file",
+                                                          "project-xy.zip",
+                                                          "project/zip",
+                                                          resourceAsByteArray("project/project-xy.zip"));
+
+        String overridingName = "overridingName";
+
+        mockMvc.perform(multipart("{version}/projects/import?name=" + overridingName,
+                                  API_VERSION).file(zipFile).accept(APPLICATION_JSON_VALUE))
+                .andDo(print()).andExpect(status().isCreated()).andExpect(jsonPath("$.entry.name",
+                                                                                   is(overridingName)));
+    }
+    
+    @Test
+    public void should_returnStatusCreatedAndZipName_when_importingProjectWithNullNameProvided() throws Exception {
+        MockMultipartFile zipFile = new MockMultipartFile("file",
+                                                          "project-xy.zip",
+                                                          "project/zip",
+                                                          resourceAsByteArray("project/project-xy.zip"));
+
+        mockMvc.perform(multipart("{version}/projects/import?name=",
+                                  API_VERSION).file(zipFile).accept(APPLICATION_JSON_VALUE))
+                .andDo(print()).andExpect(status().isCreated()).andExpect(jsonPath("$.entry.name",
+                                                                                   is("application-xy")));
+    }
+    
+    @Test
+    public void should_returnStatusCreatedAndZipName_when_importingProjectWithBlankNameProvided() throws Exception {
+        MockMultipartFile zipFile = new MockMultipartFile("file",
+                                                          "project-xy.zip",
+                                                          "project/zip",
+                                                          resourceAsByteArray("project/project-xy.zip"));
+
+        String overridingName = "      ";
+
+        mockMvc.perform(multipart("{version}/projects/import?name=" + overridingName,
+                                  API_VERSION).file(zipFile).accept(APPLICATION_JSON_VALUE))
+                .andDo(print()).andExpect(status().isCreated()).andExpect(jsonPath("$.entry.name",
+                                                                                   is("application-xy")));
+    }
+    
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ProjectHolder.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ProjectHolder.java
@@ -25,6 +25,8 @@ import org.activiti.cloud.organization.api.Project;
 import org.activiti.cloud.services.common.file.FileContent;
 import org.apache.commons.collections4.keyvalue.MultiKey;
 import org.apache.commons.collections4.map.MultiKeyMap;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.lang.Nullable;
 
 /**
  * Builder for projects
@@ -41,12 +43,15 @@ public class ProjectHolder {
 
   private final MultiKeyMap<String, FileContent> extensionFilesMap = new MultiKeyMap<>();
 
-  public ProjectHolder setProject(Project project) {
-    if (this.project == null) {
-      this.project = project;
+  public ProjectHolder setProject(Project project, @Nullable String name) {
+      if (this.project == null) {
+        this.project = project;
+        if (!StringUtils.isBlank(name)) {
+            this.project.setName(name);
+        }
+      }
+      return this;
     }
-    return this;
-  }
 
   public ProjectHolder addModelJsonFile(String modelName,
                                         ModelType modelType,


### PR DESCRIPTION
Add the Import Project endpoint a new optional `name` parameter that will override the name of the project that is present in the zip file