### PR TITLE
[AAE-688] Add messages to the list of nodes that can use variable mapping

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/BpmnProcessModelContent.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/converter/BpmnProcessModelContent.java
@@ -21,9 +21,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.activiti.bpmn.model.BaseElement;
+import org.activiti.bpmn.model.Message;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.CallActivity;
-import org.activiti.bpmn.model.FlowNode;
 import org.activiti.bpmn.model.Process;
 import org.activiti.bpmn.model.StartEvent;
 import org.activiti.bpmn.model.Task;
@@ -66,28 +67,28 @@ public class BpmnProcessModelContent implements ModelContent {
         return null;
     }
 
-    public Set<FlowNode> findAllNodes() {
+    public Set<BaseElement> findAllNodes() {
         return findAllNodes(Task.class,
                             CallActivity.class,
-                            StartEvent.class);
+                            StartEvent.class,
+                            Message.class);
     }
 
-    public Set<FlowNode> findAllNodes(Class<? extends FlowNode>... activityTypes) {
+    public Set<BaseElement> findAllNodes(Class<? extends BaseElement>... activityTypes) {
         return bpmnModel.getProcesses()
                 .stream()
                 .flatMap(process -> Arrays.stream(activityTypes)
-                        .map(process::findFlowElementsOfType)
+                        .map(process::findBaseElementsOfType)
                         .flatMap(List::stream)
                 )
                 .collect(Collectors.toSet());
     }
 
-    public <T extends FlowNode> Set<T> findAllNodes(Class<T> activityType) {
+    public <T extends BaseElement> Set<T> findAllNodes(Class<T> activityType) {
         return bpmnModel.getProcesses()
                 .stream()
-                .map(process -> process.findFlowElementsOfType(activityType,
-                                                               true)
-                ).flatMap(List::stream)
+                .map(process -> process.findBaseElementsOfType(activityType, true))
+                .flatMap(List::stream)
                 .collect(Collectors.toSet());
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/ProcessExtensionsTaskMappingsValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/ProcessExtensionsTaskMappingsValidator.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.organization.validation.extensions;
 
 import static java.lang.String.format;
 
+import org.activiti.bpmn.model.BaseElement;
 import org.activiti.bpmn.model.FlowNode;
 import org.activiti.cloud.organization.api.ModelValidationError;
 import org.activiti.cloud.organization.api.ValidationContext;
@@ -52,7 +53,7 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
     public Stream<ModelValidationError> validateExtensions(Extensions extensions,
                                                  BpmnProcessModelContent bpmnModel,
                                                  ValidationContext validationContext) {
-        Set<FlowNode> availableTasks = bpmnModel.findAllNodes();
+        Set<BaseElement> availableTasks = bpmnModel.findAllNodes();
         return extensions.getVariablesMappings().entrySet()
                 .stream()
                 .flatMap(taskMapping -> validateTaskMapping(bpmnModel.getId(),
@@ -65,7 +66,7 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
     private Stream<ModelValidationError> validateTaskMapping(String processId,
                                                              String taskId,
                                                              Map<ServiceTaskActionType, Map<String, ProcessVariableMapping>> extensionMapping,
-                                                             Set<FlowNode> availableTasks,
+                                                             Set<BaseElement> availableTasks,
                                                              ValidationContext context) {
         return availableTasks
                 .stream()
@@ -86,7 +87,7 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
 
     private Stream<ModelValidationError> validateTaskMappings(
             String processId,
-            FlowNode task,
+            BaseElement task,
             Map<ServiceTaskActionType, Map<String, ProcessVariableMapping>> taskMappingsMap,
             ValidationContext validationContext) {
 
@@ -100,7 +101,7 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
     }
 
     private List<TaskMapping> toTaskMappings(String processId,
-                                              FlowNode task,
+                                             BaseElement task,
                                               Map<ServiceTaskActionType, Map<String, ProcessVariableMapping>> taskMappingsMap) {
         return taskMappingsMap.entrySet()
                 .stream()

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/TaskMapping.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/TaskMapping.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.organization.validation.extensions;
 
 import java.util.Map;
 
+import org.activiti.bpmn.model.BaseElement;
 import org.activiti.bpmn.model.FlowNode;
 import org.activiti.cloud.organization.api.process.ProcessVariableMapping;
 import org.activiti.cloud.organization.api.process.ServiceTaskActionType;
@@ -29,14 +30,14 @@ public class TaskMapping {
 
     private String processId;
 
-    private FlowNode task;
+    private BaseElement task;
 
     private ServiceTaskActionType action;
 
     private Map<String, ProcessVariableMapping> processVariableMappings;
 
     public TaskMapping(String processId,
-                       FlowNode task,
+                       BaseElement task,
                        ServiceTaskActionType action,
                        Map<String, ProcessVariableMapping> processVariableMappings) {
         this.processId = processId;
@@ -49,7 +50,7 @@ public class TaskMapping {
         return processId;
     }
 
-    public FlowNode getTask() {
+    public BaseElement getTask() {
         return task;
     }
 

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/TaskMappingsServiceTaskImplementationValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/TaskMappingsServiceTaskImplementationValidator.java
@@ -20,6 +20,7 @@ import static java.lang.String.format;
 import static org.activiti.cloud.organization.api.process.ServiceTaskActionType.INPUTS;
 import static org.springframework.util.StringUtils.isEmpty;
 
+import org.activiti.bpmn.model.BaseElement;
 import org.activiti.bpmn.model.FlowNode;
 import org.activiti.bpmn.model.ServiceTask;
 import org.activiti.cloud.organization.api.ConnectorModelType;
@@ -86,7 +87,7 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
     }
 
     private Optional<ModelValidationError> validateTaskMappings(String processId,
-                                                                FlowNode task,
+                                                                BaseElement task,
                                                                 ServiceTaskActionType actionType,
                                                                 String processVariableMappingKey,
                                                                 ProcessVariableMapping processVariableMapping,
@@ -113,7 +114,7 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
                                        connectorParameterName)))));
     }
 
-    private Optional<String> getTaskImplementation(FlowNode task) {
+    private Optional<String> getTaskImplementation(BaseElement task) {
         return Optional.ofNullable(task)
                 .filter(t -> ServiceTask.class.isAssignableFrom(t.getClass()))
                 .map(ServiceTask.class::cast)


### PR DESCRIPTION
Messages use mapping for its payload. As it stands right now, messages cannot make use of this feature since they are not included as one of the elements that can contain mapping. 

This PR adds message support. In order to do that it needs to extend from Base Element instead of flow node to contain messages.

This PR depends on a few changes in the Engine: https://github.com/Activiti/Activiti/pull/2953

More info: https://issues.alfresco.com/jira/browse/AAE-688