### PR TITLE
[AAE-791] Add script support

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
@@ -230,7 +230,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
 
     @Test
@@ -253,7 +253,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
     
     @Test
@@ -276,7 +276,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
     
     @Test
@@ -299,7 +299,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
     
     @Test
@@ -324,7 +324,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
 
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelValidationControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ModelValidationControllerIT.java
@@ -501,4 +501,77 @@ public class ModelValidationControllerIT {
                                 .file(file))
                 .andExpect(status().isNoContent());
     }
+    
+    @Test
+    public void should_throwExceptiojn_when_validatingProcessWithServiceTaskImplementationSetToUnknownConnectorAction() throws Exception {
+        byte[] validContent = resourceAsByteArray("process/unknown-implementation-service-task.bpmn20.xml");
+        MockMultipartFile file = new MockMultipartFile("file",
+                                                       "process.xml",
+                                                       CONTENT_TYPE_XML,
+                                                       validContent);
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
+
+        ResultActions resultActions = mockMvc
+                .perform(multipart("{version}/models/{model_id}/validate",
+                                   API_VERSION,
+                                   processModel.getId())
+                                 .file(file));
+
+        resultActions.andExpect(status().isBadRequest());
+
+        final Exception resolvedException = resultActions.andReturn().getResolvedException();
+        assertThat(resolvedException).isInstanceOf(SemanticModelValidationException.class);
+        SemanticModelValidationException semanticModelValidationException = (SemanticModelValidationException) resolvedException;
+        assertThat(semanticModelValidationException.getValidationErrors())
+                .hasSize(1)
+                .extracting(ModelValidationError::getDescription,
+                            ModelValidationError::getValidatorSetName)
+                .contains(tuple("Invalid service implementation on service 'ServiceTask_1qr4ad0'","BPMN service task validator"));    
+    }
+    
+    @Test
+    public void should_returnStatusNoContent_when_validatingProcessWithServiceTaskImplementationSetToDMNAction() throws Exception {
+        byte[] validContent = resourceAsByteArray("process/dmn-implementation-service-task.bpmn20.xml");
+        MockMultipartFile file = new MockMultipartFile("file",
+                                                       "process.xml",
+                                                       CONTENT_TYPE_XML,
+                                                       validContent);
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
+
+        ResultActions resultActions = mockMvc
+                .perform(multipart("{version}/models/{model_id}/validate",
+                                   API_VERSION,
+                                   processModel.getId())
+                                 .file(file));
+
+        resultActions.andExpect(status().isNoContent());
+    }
+    
+    @Test
+    public void should_returnStatusNoContent_when_validatingProcessWithServiceTaskImplementationSetToScriptAction() throws Exception {
+        byte[] validContent = resourceAsByteArray("process/script-implementation-service-task.bpmn20.xml");
+        MockMultipartFile file = new MockMultipartFile("file",
+                                                       "process.xml",
+                                                       CONTENT_TYPE_XML,
+                                                       validContent);
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("project-test"));
+        Model processModel = modelRepository.createModel(processModel(project,
+                                                                      "process-model"));
+
+        ResultActions resultActions = mockMvc
+                .perform(multipart("{version}/models/{model_id}/validate",
+                                   API_VERSION,
+                                   processModel.getId())
+                                 .file(file));
+
+        resultActions.andExpect(status().isNoContent());
+    }
+    
+    
+    
+    
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process/dmn-implementation-service-task.bpmn20.xml
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process/dmn-implementation-service-task.bpmn20.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89" name="invalid-service" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="StartEvent_1">
+      <bpmn2:outgoing>SequenceFlow_1tdfy8m</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:serviceTask id="ServiceTask_1qr4ad0" implementation="dmn-connector.EXECUTE_TABLE">
+      <bpmn2:incoming>SequenceFlow_1tdfy8m</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_0co3bqk</bpmn2:outgoing>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1tdfy8m" sourceRef="StartEvent_1" targetRef="ServiceTask_1qr4ad0" />
+    <bpmn2:endEvent id="EndEvent_0jn62e8">
+      <bpmn2:incoming>SequenceFlow_0co3bqk</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_0co3bqk" sourceRef="ServiceTask_1qr4ad0" targetRef="EndEvent_0jn62e8" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1qr4ad0_di" bpmnElement="ServiceTask_1qr4ad0">
+        <dc:Bounds x="511" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tdfy8m_di" bpmnElement="SequenceFlow_1tdfy8m">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="511" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0jn62e8_di" bpmnElement="EndEvent_0jn62e8">
+        <dc:Bounds x="674" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0co3bqk_di" bpmnElement="SequenceFlow_0co3bqk">
+        <di:waypoint x="611" y="258" />
+        <di:waypoint x="674" y="258" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process/script-implementation-service-task.bpmn20.xml
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process/script-implementation-service-task.bpmn20.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89" name="invalid-service" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="StartEvent_1">
+      <bpmn2:outgoing>SequenceFlow_1tdfy8m</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:serviceTask id="ServiceTask_1qr4ad0" implementation="script.EXECUTE">
+      <bpmn2:incoming>SequenceFlow_1tdfy8m</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_0co3bqk</bpmn2:outgoing>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1tdfy8m" sourceRef="StartEvent_1" targetRef="ServiceTask_1qr4ad0" />
+    <bpmn2:endEvent id="EndEvent_0jn62e8">
+      <bpmn2:incoming>SequenceFlow_0co3bqk</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_0co3bqk" sourceRef="ServiceTask_1qr4ad0" targetRef="EndEvent_0jn62e8" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1qr4ad0_di" bpmnElement="ServiceTask_1qr4ad0">
+        <dc:Bounds x="511" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tdfy8m_di" bpmnElement="SequenceFlow_1tdfy8m">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="511" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0jn62e8_di" bpmnElement="EndEvent_0jn62e8">
+        <dc:Bounds x="674" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0co3bqk_di" bpmnElement="SequenceFlow_0co3bqk">
+        <di:waypoint x="611" y="258" />
+        <di:waypoint x="674" y="258" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process/unknown-implementation-service-task.bpmn20.xml
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process/unknown-implementation-service-task.bpmn20.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89" name="invalid-service" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="StartEvent_1">
+      <bpmn2:outgoing>SequenceFlow_1tdfy8m</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:serviceTask id="ServiceTask_1qr4ad0" implementation="unknown-connector.ACTION">
+      <bpmn2:incoming>SequenceFlow_1tdfy8m</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_0co3bqk</bpmn2:outgoing>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1tdfy8m" sourceRef="StartEvent_1" targetRef="ServiceTask_1qr4ad0" />
+    <bpmn2:endEvent id="EndEvent_0jn62e8">
+      <bpmn2:incoming>SequenceFlow_0co3bqk</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_0co3bqk" sourceRef="ServiceTask_1qr4ad0" targetRef="EndEvent_0jn62e8" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1qr4ad0_di" bpmnElement="ServiceTask_1qr4ad0">
+        <dc:Bounds x="511" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tdfy8m_di" bpmnElement="SequenceFlow_1tdfy8m">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="511" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0jn62e8_di" bpmnElement="EndEvent_0jn62e8">
+        <dc:Bounds x="674" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0co3bqk_di" bpmnElement="SequenceFlow_0co3bqk">
+        <di:waypoint x="611" y="258" />
+        <di:waypoint x="674" y="258" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
@@ -379,9 +379,7 @@ public class ModelService {
 
     public void validateModelExtensions(Model model,
                                         FileContent fileContent) {
-        ValidationContext validationContext = !modelTypeService.isJson(findModelType(model))
-                ? EMPTY_CONTEXT
-                : Optional.ofNullable(model.getProject()).map(this::createValidationContext).orElseGet(() -> createValidationContext(model));
+        ValidationContext validationContext = Optional.ofNullable(model.getProject()).map(this::createValidationContext).orElseGet(() -> createValidationContext(model));
         validateModelExtensions(model.getType(),
                                 fileContent.getFileContent(),
                                 validationContext);

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/ProcessExtensionsTaskMappingsValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/ProcessExtensionsTaskMappingsValidator.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import org.activiti.bpmn.model.FlowNode;
 import org.activiti.cloud.organization.api.ModelValidationError;
 import org.activiti.cloud.organization.api.ValidationContext;
+import org.activiti.cloud.organization.api.process.Constant;
 import org.activiti.cloud.organization.api.process.Extensions;
 import org.activiti.cloud.organization.api.process.ProcessVariableMapping;
 import org.activiti.cloud.organization.api.process.ServiceTaskActionType;
@@ -58,13 +59,21 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
                 .flatMap(taskMapping -> validateTaskMapping(bpmnModel.getId(),
                                                             taskMapping.getKey(),
                                                             taskMapping.getValue(),
+                                                            getTaskConstants(extensions,taskMapping.getKey()),
                                                             availableTasks,
                                                             validationContext));
+    }
+    
+    
+    private Map<String, Constant> getTaskConstants(Extensions extensions,
+                                                   String taskKey) {
+        return extensions.getConstants() != null ? extensions.getConstants().get(taskKey) : null;
     }
 
     private Stream<ModelValidationError> validateTaskMapping(String processId,
                                                              String taskId,
                                                              Map<ServiceTaskActionType, Map<String, ProcessVariableMapping>> extensionMapping,
+                                                             Map<String, Constant> taskConstants,
                                                              Set<FlowNode> availableTasks,
                                                              ValidationContext context) {
         return availableTasks
@@ -75,6 +84,7 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
                 .map(task -> validateTaskMappings(processId,
                                                   task,
                                                   extensionMapping,
+                                                  taskConstants,
                                                   context))
                 .orElseGet(() -> Stream.of(createModelValidationError(
                         format(UNKNOWN_TASK_VALIDATION_ERROR_PROBLEM,
@@ -88,6 +98,7 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
             String processId,
             FlowNode task,
             Map<ServiceTaskActionType, Map<String, ProcessVariableMapping>> taskMappingsMap,
+            Map<String, Constant> taskConstants,
             ValidationContext validationContext) {
 
         List<TaskMapping> taskMappings = toTaskMappings(processId,
@@ -96,6 +107,7 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
         return taskMappingsValidators
                 .stream()
                 .flatMap(validator -> validator.validateTaskMappings(taskMappings,
+                                                                     taskConstants,
                                                                      validationContext));
     }
 

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/TaskMappingsServiceTaskImplementationValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/TaskMappingsServiceTaskImplementationValidator.java
@@ -26,6 +26,7 @@ import org.activiti.cloud.organization.api.ConnectorModelType;
 import org.activiti.cloud.organization.api.Model;
 import org.activiti.cloud.organization.api.ModelValidationError;
 import org.activiti.cloud.organization.api.ValidationContext;
+import org.activiti.cloud.organization.api.process.Constant;
 import org.activiti.cloud.organization.api.process.ProcessVariableMapping;
 import org.activiti.cloud.organization.api.process.ServiceTaskActionType;
 import org.activiti.cloud.services.organization.converter.ConnectorActionParameter;
@@ -61,6 +62,7 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
 
     @Override
     public Stream<ModelValidationError> validateTaskMappings(List<TaskMapping> taskMappings,
+                                                             Map<String, Constant> taskConstants,
                                                              ValidationContext validationContext) {
         Map<String, ConnectorModelAction> availableConnectorActions = getAvailableConnectorActions(validationContext);
         return taskMappings

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/TaskMappingsValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/TaskMappingsValidator.java
@@ -17,11 +17,13 @@
 package org.activiti.cloud.services.organization.validation.extensions;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.activiti.cloud.organization.api.ModelValidationError;
 import org.activiti.cloud.organization.api.ModelValidationErrorProducer;
 import org.activiti.cloud.organization.api.ValidationContext;
+import org.activiti.cloud.organization.api.process.Constant;
 
 /**
  * Task mappings validator interface.
@@ -35,8 +37,10 @@ public interface TaskMappingsValidator extends ModelValidationErrorProducer {
      * Validate the given list of task mappings.
      * @param taskMappings the list of task mappings to validate
      * @param validationContext the validation context
+     * @param taskConstants the constants associated to the task
      * @return the stream of validation errors
      */
     Stream<ModelValidationError> validateTaskMappings(List<TaskMapping> taskMappings,
+                                                      Map<String, Constant> taskConstants,
                                                       ValidationContext validationContext);
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/process/BpmnModelServiceTaskImplementationValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/process/BpmnModelServiceTaskImplementationValidator.java
@@ -59,6 +59,8 @@ public class BpmnModelServiceTaskImplementationValidator implements BpmnModelVal
         List<String> availableImplementations = getAvailableImplementations(validationContext);
         //TODO: hardcoded decision table added -> fix this after implementation for decision table will change
         availableImplementations.add("dmn-connector.EXECUTE_TABLE");
+        
+        availableImplementations.add("script.EXECUTE");
 
         return getTasks(bpmnModel,
                         ServiceTask.class)


### PR DESCRIPTION
Add a new implementation for service tasks that will be executed by a script runtime. It is intended to work as the DMN implementation that currently exists.

In order to validate that the mapping in this "Script task" is correct (the script variables exist for the referenced script) the constants have to be added to the task mapping validator because the referenced script is in these constants.