### PR TITLE
AAE-858 Fix process extensions validators not being called

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
@@ -230,7 +230,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
 
     @Test
@@ -253,7 +253,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
     
     @Test
@@ -276,7 +276,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
     
     @Test
@@ -299,7 +299,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
     
     @Test
@@ -324,7 +324,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> context.isEmpty()));
+                                         Mockito.argThat(context -> !context.isEmpty()));
     }
 
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
@@ -379,9 +379,7 @@ public class ModelService {
 
     public void validateModelExtensions(Model model,
                                         FileContent fileContent) {
-        ValidationContext validationContext = !modelTypeService.isJson(findModelType(model))
-                ? EMPTY_CONTEXT
-                : Optional.ofNullable(model.getProject()).map(this::createValidationContext).orElseGet(() -> createValidationContext(model));
+        ValidationContext validationContext = Optional.ofNullable(model.getProject()).map(this::createValidationContext).orElseGet(() -> createValidationContext(model));
         validateModelExtensions(model.getType(),
                                 fileContent.getFileContent(),
                                 validationContext);


### PR DESCRIPTION
Process extensions validators that need the validation context are not being called because the validation context is empty.

The validation context is only created when the validator is for a JSON model, but it should be created always.