### PR TITLE
[AAE-858] Revert AAE-858 Fix process extensions validators not being called

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
@@ -230,7 +230,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> !context.isEmpty()));
+                                         Mockito.argThat(context -> context.isEmpty()));
     }
 
     @Test
@@ -253,7 +253,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> !context.isEmpty()));
+                                         Mockito.argThat(context -> context.isEmpty()));
     }
     
     @Test
@@ -276,7 +276,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> !context.isEmpty()));
+                                         Mockito.argThat(context -> context.isEmpty()));
     }
     
     @Test
@@ -299,7 +299,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> !context.isEmpty()));
+                                         Mockito.argThat(context -> context.isEmpty()));
     }
     
     @Test
@@ -324,7 +324,7 @@ public class GenericNonJsonModelTypeValidationControllerIT {
         Mockito.verify(genericNonJsonExtensionsValidator,
                        Mockito.times(1))
                 .validateModelExtensions(Mockito.argThat(content -> new String(content).equals(new String(fileContent))),
-                                         Mockito.argThat(context -> !context.isEmpty()));
+                                         Mockito.argThat(context -> context.isEmpty()));
     }
 
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/service/ModelService.java
@@ -379,7 +379,9 @@ public class ModelService {
 
     public void validateModelExtensions(Model model,
                                         FileContent fileContent) {
-        ValidationContext validationContext = Optional.ofNullable(model.getProject()).map(this::createValidationContext).orElseGet(() -> createValidationContext(model));
+        ValidationContext validationContext = !modelTypeService.isJson(findModelType(model))
+                ? EMPTY_CONTEXT
+                : Optional.ofNullable(model.getProject()).map(this::createValidationContext).orElseGet(() -> createValidationContext(model));
         validateModelExtensions(model.getType(),
                                 fileContent.getFileContent(),
                                 validationContext);


### PR DESCRIPTION
The bug tried to fix in AAE-858 is not a bug really. the system is working as expected. Process Extensions Validators that needs the content of the process file for validation only should be called when exporting the project, but not when calling to the `/validate/extensions` API endpoint. That is why the validation context was created as an empty context.

This reverts commit 66664293e753bf0fbf7e85ce6639427a214c6abd.