### PR TITLE
[AAE-871] Allow values in output mapping

### DIFF
--- a/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/ProcessVariableMapping.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-api/src/main/java/org/activiti/cloud/organization/api/process/ProcessVariableMapping.java
@@ -30,7 +30,7 @@ public class ProcessVariableMapping {
 
     private VariableMappingType type;
 
-    private String value;
+    private Object value;
 
     public VariableMappingType getType() {
         return type;
@@ -40,11 +40,11 @@ public class ProcessVariableMapping {
         this.type = type;
     }
 
-    public String getValue() {
+    public Object getValue() {
         return value;
     }
 
-    public void setValue(String value) {
+    public void setValue(Object value) {
         this.value = value;
     }
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ProjectControllerIT.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/java/org/activiti/cloud/services/organization/rest/controller/ProjectControllerIT.java
@@ -821,5 +821,25 @@ public class ProjectControllerIT {
                 .andDo(print()).andExpect(status().isCreated()).andExpect(jsonPath("$.entry.name",
                                                                                    is("application-xy")));
     }
+    
+    @Test
+    public void should_returnStatusOK_when_exportingProjectWithProcessExtensionsWithValueOutputProcessVariableMapping() throws Exception {
+        ProjectEntity project = (ProjectEntity) projectRepository.createProject(project("invalid-project"));
+        Model processModel = modelService.importSingleModel(project,
+                                                            processModelType,
+                                                            processFileContent("RankMovie",
+                                                                               resourceAsByteArray("process/RankMovie.bpmn20.xml")));
+        modelRepository.updateModel(processModel,
+                                    processModelWithExtensions("process-model",
+                                                               extensions(resourceAsByteArray("process-extensions/RankMovie-extensions-value-output-process-variable.json"))));
+        modelRepository.createModel(connectorModel(project,
+                                                   "movies",
+                                                   resourceAsByteArray("connector/movies.json")));
+
+        mockMvc.perform(get("{version}/projects/{projectId}/export",
+                            API_VERSION,
+                            project.getId()))
+                .andExpect(status().isOk());
+    }
 
 }

--- a/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process-extensions/RankMovie-extensions-value-output-process-variable.json
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-rest/src/test/resources/process-extensions/RankMovie-extensions-value-output-process-variable.json
@@ -1,0 +1,43 @@
+{
+    "id": "process-98ff0720-f94b-40a7-84f6-a9c8fab70568",
+    "type": "PROCESS",
+    "name": "RankMovie",
+    "extensions": {
+        "properties": {
+            "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
+                "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
+                "name": "movieToRank",
+                "type": "string",
+                "required": true
+            },
+            "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
+                "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
+                "name": "movieDesc",
+                "type": "string",
+                "required": false
+            },
+            "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
+                "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
+                "name": "rating",
+                "type": "integer",
+                "required": false
+            }
+        },
+        "mappings": {
+            "Task_1spvopd": {
+                "inputs": {
+                    "movieName": {
+                        "type": "value",
+                        "value": "movieToRank"
+                    }
+                },
+                "outputs": {
+                    "ranking-output-variable": {
+                        "type": "value",
+                        "value": 22
+                    }
+                }
+            }
+        }
+    }
+}

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/ProcessExtensionsProcessVariablesValidator.java
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/java/org/activiti/cloud/services/organization/validation/extensions/ProcessExtensionsProcessVariablesValidator.java
@@ -77,7 +77,7 @@ public class ProcessExtensionsProcessVariablesValidator implements ProcessExtens
                                                                           ProcessVariableMapping processVariableMapping,
                                                                           String processId,
                                                                           Set<String> availableProcessVariables) {
-        String variableName = action == INPUTS ? processVariableMapping.getValue() : processVariableMappingKey;
+        Object variableName = action == INPUTS ? processVariableMapping.getValue() : processVariableMappingKey;
         return processVariableMapping.getType() == VARIABLE &&
                 !availableProcessVariables.contains(variableName) ?
                 Optional.of(createModelValidationError(

--- a/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/resources/schema/process-extensions-schema.json
+++ b/activiti-cloud-services-org/activiti-cloud-services-org-service/src/main/resources/schema/process-extensions-schema.json
@@ -205,7 +205,7 @@
           ]
         },
         "value": {
-          "type": "string"
+          "type": ["string", "number", "integer", "boolean", "object", "array"]
         }
       },
       "dependencies": {
@@ -215,7 +215,25 @@
         "value": [
           "type"
         ]
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "variable"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
     },
     "constants": {
       "type": "object",


### PR DESCRIPTION
To allow expressions in output mappings as required in [this ticket ](https://issues.alfresco.com/jira/browse/AAE-871) we need 2 modifications:

- Support the "VALUE" type in output mappings
- Support values different from strings in the value mappings, so we can use something like this in the mappings
```
{
  "user": "Demo user"
  "age": ${integerProcessVar}
}
```