### PR TITLE
[AAE-1248] - Include the connector events in the schema related to them

### DIFF
--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ConnectorValidationControllerIT.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ConnectorValidationControllerIT.java
@@ -99,6 +99,22 @@ public class ConnectorValidationControllerIT {
     }
 
     @Test
+    public void should_returnStatusNoContent_when_validatingConnectorWithEvents() throws IOException {
+        Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
+
+        given()
+                .multiPart("file",
+                        "simple-connector.json",
+                        resourceAsByteArray("connector/connector-with-events.json"),
+                        "text/plain")
+                .post("/v1/models/{modelId}/validate",
+                        connectorModel.getId())
+                .then()
+                .expect(status().isNoContent())
+                .body(isEmptyString());
+    }
+
+    @Test
     public void should_throwSemanticValidationException_when_validatingInvalidSimpleConnector() throws IOException {
         Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
 

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ConnectorValidationControllerIT.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ConnectorValidationControllerIT.java
@@ -104,7 +104,7 @@ public class ConnectorValidationControllerIT {
 
         given()
                 .multiPart("file",
-                        "simple-connector.json",
+                        "connector-with-events.json",
                         resourceAsByteArray("connector/connector-with-events.json"),
                         "text/plain")
                 .post("/v1/models/{modelId}/validate",

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/connector/connector-with-events.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/connector/connector-with-events.json
@@ -1,0 +1,78 @@
+{
+  "name": "name-of-the-connector",
+  "description": "Description of the connector",
+  "actions": {
+    "actionId1": {
+      "id": "actionId1",
+      "name": "actionName1",
+      "description": "description",
+      "inputs": [
+        {
+          "id": "input-variable-1",
+          "name": "input-variable-name-1",
+          "type": "string",
+          "required": false,
+          "description": "description"
+        },
+        {
+          "id": "input-variable-2",
+          "name": "input-variable-name-2",
+          "type": "boolean",
+          "required": false,
+          "description": ""
+        }
+      ],
+      "outputs": [
+        {
+          "id": "output-variable-1",
+          "name": "output-variable-name-1",
+          "type": "string",
+          "description": ""
+        },
+        {
+          "id": "output-variable-2",
+          "name": "output-variable-name-2",
+          "type": "string",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "events": {
+    "eventId1": {
+      "id": "eventId1",
+      "name": "eventName1",
+      "description": "description",
+      "inputs": [
+        {
+          "id": "input-variable-1",
+          "name": "input-variable-name-1",
+          "type": "string",
+          "required": false,
+          "description": "description"
+        },
+        {
+          "id": "input-variable-2",
+          "name": "input-variable-name-2",
+          "type": "boolean",
+          "required": false,
+          "description": ""
+        }
+      ],
+      "outputs": [
+        {
+          "id": "output-variable-1",
+          "name": "output-variable-name-1",
+          "type": "string",
+          "description": ""
+        },
+        {
+          "id": "output-variable-2",
+          "name": "output-variable-name-2",
+          "type": "string",
+          "description": ""
+        }
+      ]
+    }
+  }
+}

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/converter/ConnectorModelContent.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/converter/ConnectorModelContent.java
@@ -37,7 +37,9 @@ public class ConnectorModelContent implements ModelContent {
 
     private String template;
 
-    private Map<String, ConnectorModelAction> actions;
+    private Map<String, ConnectorModelFeature> actions;
+
+    private Map<String, ConnectorModelFeature> events;
 
     @Override
     public String getId() {
@@ -65,11 +67,19 @@ public class ConnectorModelContent implements ModelContent {
         this.template = template;
     }
 
-    public Map<String, ConnectorModelAction> getActions() {
+    public Map<String, ConnectorModelFeature> getActions() {
         return actions;
     }
 
-    public void setActions(Map<String, ConnectorModelAction> actions) {
+    public void setActions(Map<String, ConnectorModelFeature> actions) {
         this.actions = actions;
+    }
+
+    public Map<String, ConnectorModelFeature> getEvents() {
+        return events;
+    }
+
+    public void setEvents(Map<String, ConnectorModelFeature> events) {
+        this.events = events;
     }
 }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/converter/ConnectorModelFeature.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/converter/ConnectorModelFeature.java
@@ -26,7 +26,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
-public class ConnectorModelAction {
+public class ConnectorModelFeature {
 
     private String id;
     private String name;

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/TaskMappingsServiceTaskImplementationValidator.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/TaskMappingsServiceTaskImplementationValidator.java
@@ -32,7 +32,7 @@ import org.activiti.cloud.modeling.api.process.ProcessVariableMapping;
 import org.activiti.cloud.modeling.api.process.ServiceTaskActionType;
 import org.activiti.cloud.modeling.api.process.VariableMappingType;
 import org.activiti.cloud.services.modeling.converter.ConnectorActionParameter;
-import org.activiti.cloud.services.modeling.converter.ConnectorModelAction;
+import org.activiti.cloud.services.modeling.converter.ConnectorModelFeature;
 import org.activiti.cloud.services.modeling.converter.ConnectorModelContentConverter;
 
 import java.util.Arrays;
@@ -66,7 +66,7 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
     public Stream<ModelValidationError> validateTaskMappings(List<TaskMapping> taskMappings,
                                                              Map<String, Constant> taskConstants,
                                                              ValidationContext validationContext) {
-        Map<String, ConnectorModelAction> availableConnectorActions = getAvailableConnectorActions(validationContext);
+        Map<String, ConnectorModelFeature> availableConnectorActions = getAvailableConnectorActions(validationContext);
         return taskMappings
                 .stream()
                 .flatMap(taskMapping -> validateTaskMapping(taskMapping,
@@ -74,7 +74,7 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
     }
 
     private Stream<ModelValidationError> validateTaskMapping(TaskMapping taskMapping,
-                                                            Map<String, ConnectorModelAction> availableConnectorActions) {
+                                                            Map<String, ConnectorModelFeature> availableConnectorActions) {
         return taskMapping
                 .getProcessVariableMappings()
                 .entrySet()
@@ -94,7 +94,7 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
                                                                 ServiceTaskActionType actionType,
                                                                 String processVariableMappingKey,
                                                                 ProcessVariableMapping processVariableMapping,
-                                                                Map<String, ConnectorModelAction> availableConnectorActions) {
+                                                                Map<String, ConnectorModelFeature> availableConnectorActions) {
 
         if(actionType == OUTPUTS && processVariableMapping.getType() == VariableMappingType.VALUE) {
             return Optional.<ModelValidationError>empty();
@@ -128,8 +128,8 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
                 .map(ServiceTask::getImplementation);
     }
 
-    private Map<String, ConnectorModelAction> getAvailableConnectorActions(ValidationContext validationContext) {
-        Map<String, ConnectorModelAction> availableConnectorActions = new HashMap<>();
+    private Map<String, ConnectorModelFeature> getAvailableConnectorActions(ValidationContext validationContext) {
+        Map<String, ConnectorModelFeature> availableConnectorActions = new HashMap<>();
         validationContext.getAvailableModels(connectorModelType)
                 .stream()
                 .map(Model::getContent)
@@ -145,7 +145,7 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
     }
 
     private String getImplementationKey(String connectorName,
-                                        ConnectorModelAction action) {
+                                        ConnectorModelFeature action) {
         return isEmpty(action) && isEmpty(action.getName()) ?
                 connectorName :
                 String.join(".",

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskImplementationValidator.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskImplementationValidator.java
@@ -25,7 +25,7 @@ import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.ValidationContext;
-import org.activiti.cloud.services.modeling.converter.ConnectorModelAction;
+import org.activiti.cloud.services.modeling.converter.ConnectorModelFeature;
 import org.activiti.cloud.services.modeling.converter.ConnectorModelContent;
 import org.activiti.cloud.services.modeling.converter.ConnectorModelContentConverter;
 
@@ -95,11 +95,11 @@ public class BpmnModelServiceTaskImplementationValidator implements BpmnModelVal
                 .filter(connectorModelContent -> connectorModelContent.getActions() != null);
     }
 
-    private String concatNameAndAction(ConnectorModelAction connectorModelAction,
+    private String concatNameAndAction(ConnectorModelFeature connectorModelFeature,
                                        Model model) {
-        return isEmpty(connectorModelAction) && isEmpty(connectorModelAction.getName()) ?
+        return isEmpty(connectorModelFeature) && isEmpty(connectorModelFeature.getName()) ?
                 model.getName() :
-                model.getName() + "." + connectorModelAction.getName();
+                model.getName() + "." + connectorModelFeature.getName();
     }
 
     private Optional<ModelValidationError> validateServiceTaskImplementation(ServiceTask serviceTask,

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/connector-schema.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/connector-schema.json
@@ -33,7 +33,7 @@
         "required": [ "id", "name", "type" ]
       }
     },
-    "connector-action": {
+    "connector-feature": {
       "type": "object",
       "additionalProperties" : false,
       "properties": {
@@ -54,7 +54,6 @@
       "required": [ "id", "name" ]
     }
   },
-
   "additionalProperties" : false,
   "properties": {
     "id": {
@@ -78,7 +77,12 @@
     },
     "actions" : {
       "type": "object",
-      "additionalProperties": { "$ref": "#/definitions/connector-action" },
+      "additionalProperties": { "$ref": "#/definitions/connector-feature" },
+      "default": {}
+    },
+    "events" : {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/definitions/connector-feature" },
       "default": {}
     }
   },

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/connector-schema.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/connector-schema.json
@@ -24,7 +24,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [ "string", "integer", "boolean", "date", "json", "file", "datetime", "string-list" ]
+            "enum": [ "string", "integer", "boolean", "date", "json", "file", "datetime", "array" ]
           },
           "required": {
             "type": "boolean"

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/connector-schema.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/connector-schema.json
@@ -24,7 +24,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [ "string", "integer", "boolean", "date", "json", "file" ]
+            "enum": [ "string", "integer", "boolean", "date", "json", "file", "datetime" ]
           },
           "required": {
             "type": "boolean"

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/connector-schema.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/connector-schema.json
@@ -24,7 +24,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [ "string", "integer", "boolean", "date", "json", "file", "datetime" ]
+            "enum": [ "string", "integer", "boolean", "date", "json", "file", "datetime", "string-list" ]
           },
           "required": {
             "type": "boolean"


### PR DESCRIPTION
Including the connector events in the schema related to connectors.

Maybe this IT https://github.com/Alfresco/alfresco-modeling-service/blob/develop/src/test/java/com/alfresco/process/modeling/validation/ConnectorModelValidatorIT.java should be here?