### PR TITLE
AAE-1496 - improved validation schema and fixed wrong id rewriting

### DIFF
--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/mock/MockFactory.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/mock/MockFactory.java
@@ -21,7 +21,6 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -106,7 +105,7 @@ public class MockFactory {
         ModelEntity processModel = new ModelEntity(name,
                                                    PROCESS);
         processModel.setProject(parentProject);
-        processModel.setExtensions(extensions!=null?generateExtensions(name, extensions):null);
+        processModel.setExtensions(extensions!=null? buildExtensions(name, extensions):null);
         if (content != null) {
             processModel.setContentType(CONTENT_TYPE_XML);
             processModel.setContent(content);
@@ -114,9 +113,9 @@ public class MockFactory {
         return processModel;
     }
 
-    private static Map<String, Object> generateExtensions(String name, Extensions extension) {
+    private static Map<String, Object> buildExtensions(String name, Extensions extensions) {
         Map<String, Object> generatedExtension = new HashMap<String, Object>();
-        generatedExtension.put(name, extension.getAsMap());
+        generatedExtension.put(name, extensions.getAsMap());
         return generatedExtension;
     }
 
@@ -160,7 +159,7 @@ public class MockFactory {
                                                       String content) {
         ModelEntity processModel = processModel(name);
         processModel.setProject(project);
-        processModel.setExtensions(extensions!=null?generateExtensions(name, extensions):null);
+        processModel.setExtensions(extensions!=null? buildExtensions(name, extensions):null);
         if (content != null) {
             processModel.setContentType(CONTENT_TYPE_XML);
             processModel.setContent(content.getBytes());
@@ -170,7 +169,7 @@ public class MockFactory {
 
     public static Map<String, Extensions> extensions(byte[] bytes) {
         try {
-            return getFromMap(new ObjectMapper()
+            return getExtensionMapFromJson(new ObjectMapper()
                     .readValue(bytes,
                                ModelEntity.class)
                     .getExtensions());
@@ -179,7 +178,7 @@ public class MockFactory {
         }
     }
 
-    private static Map<String, Extensions> getFromMap(Map<String,Object> map) throws IOException {
+    private static Map<String, Extensions> getExtensionMapFromJson(Map<String,Object> map) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         String exstensionJson = objectMapper.writeValueAsString(map);
         if (StringUtils.isEmpty(exstensionJson)) {

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeControllerIT.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeControllerIT.java
@@ -22,6 +22,7 @@ import static org.activiti.cloud.services.modeling.asserts.AssertResponse.assert
 import static org.activiti.cloud.services.modeling.mock.MockFactory.project;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
@@ -279,7 +280,7 @@ public class GenericJsonModelTypeControllerIT {
     }
 
     @Test
-    public void should_returnStatusCreatedAndNullExtensions_when_creatingGenericJsonModelWithNullExtensions() throws Exception {
+    public void should_returnStatusCreatedAndEmptyExtensions_when_creatingGenericJsonModelWithNullExtensions() throws Exception {
         Project project = projectRepository.createProject(project(GENERIC_PROJECT_NAME));
 
         Model genericJsonModel = modelRepository.createModel(new ModelEntity(GENERIC_MODEL_NAME,
@@ -288,10 +289,11 @@ public class GenericJsonModelTypeControllerIT {
 
         genericJsonModel.setExtensions(extensions);
 
-        given().accept(APPLICATION_JSON_VALUE).contentType(APPLICATION_JSON_VALUE).body(objectMapper.writeValueAsString(genericJsonModel)).post("/v1/projects/{projectId}/models",
-                                                                                                                                                project.getId())
-                .then().expect(status().isCreated()).body("entry.extensions",
-                                                          nullValue());
+        given().accept(APPLICATION_JSON_VALUE).contentType(APPLICATION_JSON_VALUE)
+            .body(objectMapper.writeValueAsString(genericJsonModel))
+            .post("/v1/projects/{projectId}/models", project.getId())
+            .then().expect(status().isCreated())
+            .body("entry.extensions", notNullValue());
     }
 
     @Test

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericNonJsonModelTypeControllerIT.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericNonJsonModelTypeControllerIT.java
@@ -271,7 +271,7 @@ public class GenericNonJsonModelTypeControllerIT {
     }
 
     @Test
-    public void should_returnStatusCreatedAndNullExtensions_when_creatingGenericNonJsonModelWithNullExtensions() throws Exception {
+    public void should_returnStatusCreatedAndEmptyExtensions_when_creatingGenericNonJsonModelWithNullExtensions() throws Exception {
         Project project = projectRepository.createProject(project(GENERIC_PROJECT_NAME));
 
         Model genericNonJsonModel = modelRepository.createModel(new ModelEntity(GENERIC_MODEL_NAME,
@@ -283,7 +283,7 @@ public class GenericNonJsonModelTypeControllerIT {
         given().accept(APPLICATION_JSON_VALUE).contentType(APPLICATION_JSON_VALUE).body(objectMapper.writeValueAsString(genericNonJsonModel)).post("/v1/projects/{projectId}/models",
                                                                                                                                                 project.getId())
                 .then().expect(status().isCreated()).body("entry.extensions",
-                                                          nullValue());
+                                                          notNullValue());
     }
 
     @Test

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
@@ -16,7 +16,6 @@
 
 package org.activiti.cloud.services.modeling.rest.controller;
 
-import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.withJsonPath;
 import static org.activiti.cloud.modeling.api.ProcessModelType.PROCESS;
@@ -187,9 +186,9 @@ public class ModelControllerIT {
                                         .add("myIntegerConstant",
                                              10)
                                         .build());
-        Map<String, Extensions> extensions = new HashMap<String, Extensions>();
-        extensions.put("process-model-extensions", extensions);
-        ModelEntity processModel = processModelWithExtensions("process-model-extensions", extensions);
+        Map<String, Extensions> processExtension = new HashMap<String, Extensions>();
+        processExtension.put("process-model-extensions", extensions);
+        ModelEntity processModel = processModelWithExtensions("process-model-extensions", processExtension);
         mockMvc.perform(post("{version}/projects/{projectId}/models",
                              API_VERSION,
                              project.getId())

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
@@ -187,9 +187,9 @@ public class ModelControllerIT {
                                         .add("myIntegerConstant",
                                              10)
                                         .build());
-        Map<String, Extensions> extensionsMap = new HashMap<String, Extensions>();
-        extensionsMap.put("process-model-extensions", extensions);
-        ModelEntity processModel = processModelWithExtensions("process-model-extensions", extensionsMap);
+        Map<String, Extensions> extensions = new HashMap<String, Extensions>();
+        extensions.put("process-model-extensions", extensions);
+        ModelEntity processModel = processModelWithExtensions("process-model-extensions", extensions);
         mockMvc.perform(post("{version}/projects/{projectId}/models",
                              API_VERSION,
                              project.getId())
@@ -274,14 +274,14 @@ public class ModelControllerIT {
 
     @Test
     public void should_returnStatusOkAndExtensions_when_gettingAnExistingModelWithExtensions() throws Exception {
-        Map<String, Extensions> extensionsMap = new HashMap<String, Extensions>();
-        extensionsMap.put("process-model-with-extensions",extensions("ServiceTask",  "stringVariable",
+        Map<String, Extensions> extensions = new HashMap<String, Extensions>();
+        extensions.put("process-model-with-extensions",extensions("ServiceTask",  "stringVariable",
                                                         "integerVariable",
                                                         "booleanVariable",
                                                         "dateVariable",
                                                         "jsonVariable"));
         Model processModel = modelRepository
-                .createModel(processModelWithExtensions("process-model-with-extensions", extensionsMap ));
+                .createModel(processModelWithExtensions("process-model-with-extensions", extensions ));
         mockMvc.perform(get("{version}/models/{modelId}",
                             API_VERSION,
                             processModel.getId()))
@@ -434,13 +434,13 @@ public class ModelControllerIT {
 
     @Test
     public void should_returnStatusOk_when_updatingModelWithExtensions() throws Exception {
-        Map<String, Extensions> extensionsMap = new HashMap<String, Extensions>();
-        extensionsMap.put("process-model-extensions", extensions("ServiceTask", "variable1"));
-        ModelEntity processModel = processModelWithExtensions("process-model-extensions", extensionsMap);
+        Map<String, Extensions> extensions = new HashMap<String, Extensions>();
+        extensions.put("process-model-extensions", extensions("ServiceTask", "variable1"));
+        ModelEntity processModel = processModelWithExtensions("process-model-extensions", extensions);
         modelRepository.createModel(processModel);
 
         Map<String, Extensions> secondExtensionMap = new HashMap<String, Extensions>();
-        extensionsMap.put("process-model-extensions", extensions("variable2", "variable3"));
+        extensions.put("process-model-extensions", extensions("variable2", "variable3"));
         ModelEntity newModel = processModelWithExtensions("process-model-extensions", secondExtensionMap);
         mockMvc.perform(put("{version}/models/{modelId}",
                             API_VERSION,

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
@@ -281,7 +281,7 @@ public class ModelValidationControllerIT {
                 .andDo(print());
         resultActions.andExpect(status().isBadRequest());
         assertThat(resultActions.andReturn().getResponse().getErrorMessage())
-                .isEqualTo("#/extensions/mappings/ServiceTask_06crg3b: #: only 0 subschema matches out of 2");
+                .isEqualTo("#/extensions/Process_test/mappings/ServiceTask_06crg3b: #: only 0 subschema matches out of 2");
 
         final Exception resolvedException = resultActions.andReturn().getResolvedException();
         assertThat(resolvedException).isInstanceOf(SemanticModelValidationException.class);
@@ -292,13 +292,13 @@ public class ModelValidationControllerIT {
                 .extracting(ModelValidationError::getProblem,
                             ModelValidationError::getDescription)
                 .containsOnly(tuple("extraneous key [inputds] is not permitted",
-                                    "#/extensions/mappings/ServiceTask_06crg3b: extraneous key [inputds] is not permitted"),
+                                    "#/extensions/Process_test/mappings/ServiceTask_06crg3b: extraneous key [inputds] is not permitted"),
                               tuple("extraneous key [outputss] is not permitted",
-                                    "#/extensions/mappings/ServiceTask_06crg3b: extraneous key [outputss] is not permitted"),
+                                    "#/extensions/Process_test/mappings/ServiceTask_06crg3b: extraneous key [outputss] is not permitted"),
                               tuple("required key [inputs] not found",
-                                    "#/extensions/mappings/ServiceTask_06crg3b: required key [inputs] not found"),
+                                    "#/extensions/Process_test/mappings/ServiceTask_06crg3b: required key [inputs] not found"),
                               tuple("required key [outputs] not found",
-                                    "#/extensions/mappings/ServiceTask_06crg3b: required key [outputs] not found"));
+                                    "#/extensions/Process_test/mappings/ServiceTask_06crg3b: required key [outputs] not found"));
     }
 
     @Test

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-no-default-values.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-no-default-values.json
@@ -3,41 +3,43 @@
     "type": "PROCESS",
     "name": "RankMovie",
     "extensions": {
-        "properties": {
+        "Process_RankMovieId": {
+          "properties": {
             "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
-                "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
-                "name": "movieToRank",
-                "type": "string",
-                "required": true
+              "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
+              "name": "movieToRank",
+              "type": "string",
+              "required": true
             },
             "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
-                "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
-                "name": "movieDesc",
-                "type": "string",
-                "required": false
+              "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
+              "name": "movieDesc",
+              "type": "string",
+              "required": false
             },
             "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
-                "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
-                "name": "rating",
-                "type": "integer",
-                "required": false
+              "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
+              "name": "rating",
+              "type": "integer",
+              "required": false
             }
-        },
-        "mappings": {
+          },
+          "mappings": {
             "Task_1spvopd": {
-                "inputs": {
-                    "movieName": {
-                        "type": "variable",
-                        "value": "movieToRank"
-                    }
-                },
-                "outputs": {
-                    "movieDesc": {
-                        "type": "variable",
-                        "value": "movieDescription"
-                    }
+              "inputs": {
+                "movieName": {
+                  "type": "variable",
+                  "value": "movieToRank"
                 }
+              },
+              "outputs": {
+                "movieDesc": {
+                  "type": "variable",
+                  "value": "movieDescription"
+                }
+              }
             }
+          }
         }
     }
 }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-connector-parameter.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-connector-parameter.json
@@ -3,41 +3,43 @@
     "type": "PROCESS",
     "name": "RankMovie",
     "extensions": {
+      "Process_RankMovieId": {
         "properties": {
-            "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
-                "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
-                "name": "movieToRank",
-                "type": "string",
-                "required": true
-            },
-            "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
-                "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
-                "name": "movieDesc",
-                "type": "string",
-                "required": false
-            },
-            "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
-                "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
-                "name": "rating",
-                "type": "integer",
-                "required": false
-            }
+          "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
+            "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
+            "name": "movieToRank",
+            "type": "string",
+            "required": true
+          },
+          "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
+            "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
+            "name": "movieDesc",
+            "type": "string",
+            "required": false
+          },
+          "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
+            "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
+            "name": "rating",
+            "type": "integer",
+            "required": false
+          }
         },
         "mappings": {
-            "Task_1spvopd": {
-                "inputs": {
-                    "unknown-input-parameter": {
-                        "type": "variable",
-                        "value": "movieToRank"
-                    }
-                },
-                "outputs": {
-                    "movieDesc": {
-                        "type": "variable",
-                        "value": "unknown-output-parameter"
-                    }
-                }
+          "Task_1spvopd": {
+            "inputs": {
+              "unknown-input-parameter": {
+                "type": "variable",
+                "value": "movieToRank"
+              }
+            },
+            "outputs": {
+              "movieDesc": {
+                "type": "variable",
+                "value": "unknown-output-parameter"
+              }
             }
+          }
         }
+      }
     }
 }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-input-process-variable.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-input-process-variable.json
@@ -3,41 +3,43 @@
     "type": "PROCESS",
     "name": "RankMovie",
     "extensions": {
+      "Process_RankMovieId": {
         "properties": {
-            "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
-                "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
-                "name": "movieToRank",
-                "type": "string",
-                "required": true
-            },
-            "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
-                "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
-                "name": "movieDesc",
-                "type": "string",
-                "required": false
-            },
-            "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
-                "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
-                "name": "rating",
-                "type": "integer",
-                "required": false
-            }
+          "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
+            "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
+            "name": "movieToRank",
+            "type": "string",
+            "required": true
+          },
+          "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
+            "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
+            "name": "movieDesc",
+            "type": "string",
+            "required": false
+          },
+          "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
+            "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
+            "name": "rating",
+            "type": "integer",
+            "required": false
+          }
         },
         "mappings": {
-            "Task_1spvopd": {
-                "inputs": {
-                    "movieName": {
-                        "type": "variable",
-                        "value": "unknown-input-variable"
-                    }
-                },
-                "outputs": {
-                    "movieDesc": {
-                        "type": "variable",
-                        "value": "movieDescription"
-                    }
-                }
+          "Task_1spvopd": {
+            "inputs": {
+              "movieName": {
+                "type": "variable",
+                "value": "unknown-input-variable"
+              }
+            },
+            "outputs": {
+              "movieDesc": {
+                "type": "variable",
+                "value": "movieDescription"
+              }
             }
+          }
         }
+      }
     }
 }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-output-process-variable.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-output-process-variable.json
@@ -3,41 +3,43 @@
     "type": "PROCESS",
     "name": "RankMovie",
     "extensions": {
+      "Process_RankMovieId": {
         "properties": {
-            "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
-                "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
-                "name": "movieToRank",
-                "type": "string",
-                "required": true
-            },
-            "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
-                "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
-                "name": "movieDesc",
-                "type": "string",
-                "required": false
-            },
-            "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
-                "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
-                "name": "rating",
-                "type": "integer",
-                "required": false
-            }
+          "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
+            "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
+            "name": "movieToRank",
+            "type": "string",
+            "required": true
+          },
+          "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
+            "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
+            "name": "movieDesc",
+            "type": "string",
+            "required": false
+          },
+          "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
+            "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
+            "name": "rating",
+            "type": "integer",
+            "required": false
+          }
         },
         "mappings": {
-            "Task_1spvopd": {
-                "inputs": {
-                    "movieName": {
-                        "type": "variable",
-                        "value": "movieToRank"
-                    }
-                },
-                "outputs": {
-                    "unknown-output-variable": {
-                        "type": "variable",
-                        "value": "movieDescription"
-                    }
-                }
+          "Task_1spvopd": {
+            "inputs": {
+              "movieName": {
+                "type": "variable",
+                "value": "movieToRank"
+              }
+            },
+            "outputs": {
+              "unknown-output-variable": {
+                "type": "variable",
+                "value": "movieDescription"
+              }
             }
+          }
         }
+      }
     }
 }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-task.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions-unknown-task.json
@@ -3,41 +3,43 @@
     "type": "PROCESS",
     "name": "RankMovie",
     "extensions": {
+      "Process_RankMovieId": {
         "properties": {
-            "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
-                "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
-                "name": "movieToRank",
-                "type": "string",
-                "required": true
-            },
-            "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
-                "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
-                "name": "movieDesc",
-                "type": "string",
-                "required": false
-            },
-            "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
-                "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
-                "name": "rating",
-                "type": "integer",
-                "required": false
-            }
+          "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
+            "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
+            "name": "movieToRank",
+            "type": "string",
+            "required": true
+          },
+          "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
+            "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
+            "name": "movieDesc",
+            "type": "string",
+            "required": false
+          },
+          "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
+            "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
+            "name": "rating",
+            "type": "integer",
+            "required": false
+          }
         },
         "mappings": {
-            "unknown-task": {
-                "inputs": {
-                    "movieName": {
-                        "type": "variable",
-                        "value": "movieToRank"
-                    }
-                },
-                "outputs": {
-                    "movieDesc": {
-                        "type": "variable",
-                        "value": "movieDescription"
-                    }
-                }
+          "unknown-task": {
+            "inputs": {
+              "movieName": {
+                "type": "variable",
+                "value": "movieToRank"
+              }
+            },
+            "outputs": {
+              "movieDesc": {
+                "type": "variable",
+                "value": "movieDescription"
+              }
             }
+          }
         }
+      }
     }
 }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/RankMovie-extensions.json
@@ -3,41 +3,43 @@
   "type": "PROCESS",
   "name": "RankMovie",
   "extensions": {
-    "properties": {
-      "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
-        "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
-        "name": "movieToRank",
-        "type": "string",
-        "required": true,
-        "value": ""
-      },
-      "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
-        "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
-        "name": "movieDesc",
-        "type": "string",
-        "required": false,
-        "value": ""
-      },
-      "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
-        "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
-        "name": "rating",
-        "type": "integer",
-        "required": false,
-        "value": 0
-      }
-    },
-    "mappings": {
-      "Task_1spvopd": {
-        "inputs": {
-          "movieName": {
-            "type": "variable",
-            "value": "movieToRank"
-          }
+    "Process_RankMovieId": {
+      "properties": {
+        "0d9ff66b-4d12-4ec7-b8c6-2082468cd885": {
+          "id": "0d9ff66b-4d12-4ec7-b8c6-2082468cd885",
+          "name": "movieToRank",
+          "type": "string",
+          "required": true,
+          "value": ""
         },
-        "outputs": {
-          "movieDesc": {
-            "type": "variable",
-            "value": "movieDescription"
+        "b6d935ce-6cc8-49f8-8339-8ceece2a48d2": {
+          "id": "b6d935ce-6cc8-49f8-8339-8ceece2a48d2",
+          "name": "movieDesc",
+          "type": "string",
+          "required": false,
+          "value": ""
+        },
+        "fdc1dc9f-9123-4fec-bab7-a938fb01906e": {
+          "id": "fdc1dc9f-9123-4fec-bab7-a938fb01906e",
+          "name": "rating",
+          "type": "integer",
+          "required": false,
+          "value": 0
+        }
+      },
+      "mappings": {
+        "Task_1spvopd": {
+          "inputs": {
+            "movieName": {
+              "type": "variable",
+              "value": "movieToRank"
+            }
+          },
+          "outputs": {
+            "movieDesc": {
+              "type": "variable",
+              "value": "movieDescription"
+            }
           }
         }
       }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-boolean-variable-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-boolean-variable-extensions.json
@@ -1,40 +1,42 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "mappings": {
-      "ServiceTask_06crg3b": {
-        "inputs": {
-          "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
-            "type": "variable",
-            "value": "db995012-b417-4cea-a981-cef287de8e4a"
+    "Process_test": {
+      "mappings": {
+        "ServiceTask_06crg3b": {
+          "inputs": {
+            "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
+              "type": "variable",
+              "value": "db995012-b417-4cea-a981-cef287de8e4a"
+            },
+            "aa4a9329-71be-4889-8265-398b68536d4a": {
+              "type": "variable",
+              "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+            }
           },
-          "aa4a9329-71be-4889-8265-398b68536d4a": {
-            "type": "variable",
+          "outputs": {
+            "7d74c83b-6d52-48db-a816-1d4992a40947": {
+              "type": "value",
+              "value": "test"
+            }
+          }
+        }
+      },
+      "constants": {
+        "ServiceTask_06crg3b": {
+          "my-custom-variable": {
             "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
           }
-        },
-        "outputs": {
-          "7d74c83b-6d52-48db-a816-1d4992a40947": {
-            "type": "value",
-            "value": "test"
-          }
         }
-      }
-    },
-    "constants": {
-      "ServiceTask_06crg3b": {
-        "my-custom-variable": {
-          "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+      },
+      "properties": {
+        "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "booleanVariable",
+          "type": "boolean",
+          "required": false,
+          "value": 12
         }
-      }
-    },
-    "properties": {
-      "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "booleanVariable",
-        "type": "boolean",
-        "required": false,
-        "value": 12
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-date-variable-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-date-variable-extensions.json
@@ -1,48 +1,50 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "mappings": {
-      "ServiceTask_06crg3b": {
-        "inputs": {
-          "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
-            "type": "variable",
-            "value": "db995012-b417-4cea-a981-cef287de8e4a"
+    "Process_test": {
+      "mappings": {
+        "ServiceTask_06crg3b": {
+          "inputs": {
+            "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
+              "type": "variable",
+              "value": "db995012-b417-4cea-a981-cef287de8e4a"
+            },
+            "aa4a9329-71be-4889-8265-398b68536d4a": {
+              "type": "variable",
+              "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+            }
           },
-          "aa4a9329-71be-4889-8265-398b68536d4a": {
-            "type": "variable",
+          "outputs": {
+            "7d74c83b-6d52-48db-a816-1d4992a40947": {
+              "type": "value",
+              "value": "test"
+            }
+          }
+        }
+      },
+      "constants" : {
+        "ServiceTask_06crg3b": {
+          "my-custom-variable": {
             "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
           }
-        },
-        "outputs": {
-          "7d74c83b-6d52-48db-a816-1d4992a40947": {
-            "type": "value",
-            "value": "test"
-          }
-        }
-      }
-    },
-    "constants" : {
-      "ServiceTask_06crg3b": {
-        "my-custom-variable": {
-          "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
-        }
 
-      }
-    },
-    "properties": {
-      "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "dateVariable",
-        "type": "date",
-        "required": false,
-        "value": 12
+        }
       },
-      "c297ec88-0ecf-4841-9b0f-2ae814957c64": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "dateVariable",
-        "type": "date",
-        "required": false,
-        "value": "aloha"
+      "properties": {
+        "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "dateVariable",
+          "type": "date",
+          "required": false,
+          "value": 12
+        },
+        "c297ec88-0ecf-4841-9b0f-2ae814957c64": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "dateVariable",
+          "type": "date",
+          "required": false,
+          "value": "aloha"
+        }
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-datetime-variable-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-datetime-variable-extensions.json
@@ -1,77 +1,79 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "mappings": {},
-    "constants": {},
-    "properties": {
-      "5bbf80a5-88d9-4204-9ba3-e8f1f3d1a7d8": {
-        "id": "5bbf80a5-88d9-4204-9ba3-e8f1f3d1a7d8",
-        "name": "emptyDate",
-        "type": "datetime",
-        "required": false
-      },
-      "047f9acb-7dd8-41f6-b116-19431104a7c4": {
-        "id": "047f9acb-7dd8-41f6-b116-19431104a7c4",
-        "name": "case1",
-        "type": "datetime",
-        "required": false,
-        "value": "2019-12-06T00:00:00"
-      },
-      "eba7ddad-930c-4ee3-ab77-9dcc3af5b267": {
-        "id": "eba7ddad-930c-4ee3-ab77-9dcc3af5b267",
-        "name": "case2",
-        "type": "datetime",
-        "required": false,
-        "value": "2019-12-06T00:05:00"
-      },
-      "60249b9b-ca13-452e-a363-f65a73235cd6": {
-        "id": "60249b9b-ca13-452e-a363-f65a73235cd6",
-        "name": "case3",
-        "type": "datetime",
-        "required": false,
-        "value": "2019-12-06T00:10:10"
-      },
-      "39175eb2-5246-4f80-a778-b972ee0224e5": {
-        "id": "39175eb2-5246-4f80-a778-b972ee0224e5",
-        "name": "case5",
-        "type": "datetime",
-        "required": false,
-        "value": "2019-12-06T12:10:10"
-      },
-      "e0740a3a-fec4-4ee5-bece-61f39df2a47d": {
-        "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47d",
-        "name": "case4",
-        "type": "datetime",
-        "required": false,
-        "value": "2019-12-06T23:59:59"
-      },
-      "e0740a3a-fec4-4ee5-bece-61f39df2a47e": {
-        "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47e",
-        "name": "case4",
-        "type": "datetime",
-        "required": false,
-        "value": "2019-12-06T24:00:00"
-      },
-      "e0740a3a-fec4-4ee5-bece-61f39df2a47f": {
-        "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47f",
-        "name": "case4",
-        "type": "datetime",
-        "required": false,
-        "value": "2019-12-06T00:00:60"
-      },
-      "e0740a3a-fec4-4ee5-bece-61f39df2a47g": {
-        "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47g",
-        "name": "case4",
-        "type": "datetime",
-        "required": false,
-        "value": "2019-12-06T00:60:00"
-      },
-      "e0740a3a-fec4-4ee5-bece-61f39df2a47k": {
-        "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47k",
-        "name": "case4",
-        "type": "datetime",
-        "required": false,
-        "value": 12
+    "Process_x": {
+      "mappings": {},
+      "constants": {},
+      "properties": {
+        "5bbf80a5-88d9-4204-9ba3-e8f1f3d1a7d8": {
+          "id": "5bbf80a5-88d9-4204-9ba3-e8f1f3d1a7d8",
+          "name": "emptyDate",
+          "type": "datetime",
+          "required": false
+        },
+        "047f9acb-7dd8-41f6-b116-19431104a7c4": {
+          "id": "047f9acb-7dd8-41f6-b116-19431104a7c4",
+          "name": "case1",
+          "type": "datetime",
+          "required": false,
+          "value": "2019-12-06T00:00:00"
+        },
+        "eba7ddad-930c-4ee3-ab77-9dcc3af5b267": {
+          "id": "eba7ddad-930c-4ee3-ab77-9dcc3af5b267",
+          "name": "case2",
+          "type": "datetime",
+          "required": false,
+          "value": "2019-12-06T00:05:00"
+        },
+        "60249b9b-ca13-452e-a363-f65a73235cd6": {
+          "id": "60249b9b-ca13-452e-a363-f65a73235cd6",
+          "name": "case3",
+          "type": "datetime",
+          "required": false,
+          "value": "2019-12-06T00:10:10"
+        },
+        "39175eb2-5246-4f80-a778-b972ee0224e5": {
+          "id": "39175eb2-5246-4f80-a778-b972ee0224e5",
+          "name": "case5",
+          "type": "datetime",
+          "required": false,
+          "value": "2019-12-06T12:10:10"
+        },
+        "e0740a3a-fec4-4ee5-bece-61f39df2a47d": {
+          "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47d",
+          "name": "case4",
+          "type": "datetime",
+          "required": false,
+          "value": "2019-12-06T23:59:59"
+        },
+        "e0740a3a-fec4-4ee5-bece-61f39df2a47e": {
+          "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47e",
+          "name": "case4",
+          "type": "datetime",
+          "required": false,
+          "value": "2019-12-06T24:00:00"
+        },
+        "e0740a3a-fec4-4ee5-bece-61f39df2a47f": {
+          "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47f",
+          "name": "case4",
+          "type": "datetime",
+          "required": false,
+          "value": "2019-12-06T00:00:60"
+        },
+        "e0740a3a-fec4-4ee5-bece-61f39df2a47g": {
+          "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47g",
+          "name": "case4",
+          "type": "datetime",
+          "required": false,
+          "value": "2019-12-06T00:60:00"
+        },
+        "e0740a3a-fec4-4ee5-bece-61f39df2a47k": {
+          "id": "e0740a3a-fec4-4ee5-bece-61f39df2a47k",
+          "name": "case4",
+          "type": "datetime",
+          "required": false,
+          "value": 12
+        }
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-integer-variable-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-integer-variable-extensions.json
@@ -1,40 +1,42 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "mappings": {
-      "ServiceTask_06crg3b": {
-        "inputs": {
-          "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
-            "type": "variable",
-            "value": "db995012-b417-4cea-a981-cef287de8e4a"
+    "Process_check": {
+      "mappings": {
+        "ServiceTask_06crg3b": {
+          "inputs": {
+            "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
+              "type": "variable",
+              "value": "db995012-b417-4cea-a981-cef287de8e4a"
+            },
+            "aa4a9329-71be-4889-8265-398b68536d4a": {
+              "type": "variable",
+              "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+            }
           },
-          "aa4a9329-71be-4889-8265-398b68536d4a": {
-            "type": "variable",
+          "outputs": {
+            "7d74c83b-6d52-48db-a816-1d4992a40947": {
+              "type": "value",
+              "value": "test"
+            }
+          }
+        }
+      },
+      "constants": {
+        "ServiceTask_06crg3b": {
+          "my-custom-variable": {
             "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
           }
-        },
-        "outputs": {
-          "7d74c83b-6d52-48db-a816-1d4992a40947": {
-            "type": "value",
-            "value": "test"
-          }
         }
-      }
-    },
-    "constants": {
-      "ServiceTask_06crg3b": {
-        "my-custom-variable": {
-          "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+      },
+      "properties": {
+        "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "integerVariable",
+          "type": "integer",
+          "required": false,
+          "value": "aloha"
         }
-      }
-    },
-    "properties": {
-      "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "integerVariable",
-        "type": "integer",
-        "required": false,
-        "value": "aloha"
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-mapping-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-mapping-extensions.json
@@ -1,40 +1,42 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "mappings": {
-      "ServiceTask_06crg3b": {
-        "inputds": {
-          "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
-            "type": "variable",
-            "value": "db995012-b417-4cea-a981-cef287de8e4a"
+    "Process_test": {
+      "mappings": {
+        "ServiceTask_06crg3b": {
+          "inputds": {
+            "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
+              "type": "variable",
+              "value": "db995012-b417-4cea-a981-cef287de8e4a"
+            },
+            "aa4a9329-71be-4889-8265-398b68536d4a": {
+              "type": "variable",
+              "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+            }
           },
-          "aa4a9329-71be-4889-8265-398b68536d4a": {
-            "type": "variable",
-            "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
-          }
-        },
-        "outputss": {
-          "7d74c83b-6d52-48db-a816-1d4992a40947": {
-            "type": "value",
-            "value": "test"
+          "outputss": {
+            "7d74c83b-6d52-48db-a816-1d4992a40947": {
+              "type": "value",
+              "value": "test"
+            }
           }
         }
-      }
-    },
-    "properties": {
-      "db995012-b417-4cea-a981-cef287de8e4a": {
-        "id": "db995012-b417-4cea-a981-cef287de8e4a",
-        "name": "name1",
-        "type": "string",
-        "required": false,
-        "value": "as"
       },
-      "ee9eb6d4-8cd6-4098-8340-13ce2f470faa": {
-        "id": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa",
-        "name": "name2",
-        "type": "string",
-        "required": false,
-        "value": "aloha"
+      "properties": {
+        "db995012-b417-4cea-a981-cef287de8e4a": {
+          "id": "db995012-b417-4cea-a981-cef287de8e4a",
+          "name": "name1",
+          "type": "string",
+          "required": false,
+          "value": "as"
+        },
+        "ee9eb6d4-8cd6-4098-8340-13ce2f470faa": {
+          "id": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa",
+          "name": "name2",
+          "type": "string",
+          "required": false,
+          "value": "aloha"
+        }
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-object-variable-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-object-variable-extensions.json
@@ -1,40 +1,42 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "mappings": {
-      "ServiceTask_06crg3b": {
-        "inputs": {
-          "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
-            "type": "variable",
-            "value": "db995012-b417-4cea-a981-cef287de8e4a"
+    "Process_test": {
+      "mappings": {
+        "ServiceTask_06crg3b": {
+          "inputs": {
+            "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
+              "type": "variable",
+              "value": "db995012-b417-4cea-a981-cef287de8e4a"
+            },
+            "aa4a9329-71be-4889-8265-398b68536d4a": {
+              "type": "variable",
+              "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+            }
           },
-          "aa4a9329-71be-4889-8265-398b68536d4a": {
-            "type": "variable",
+          "outputs": {
+            "7d74c83b-6d52-48db-a816-1d4992a40947": {
+              "type": "value",
+              "value": "test"
+            }
+          }
+        }
+      },
+      "constants": {
+        "ServiceTask_06crg3b": {
+          "my-custom-variable": {
             "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
           }
-        },
-        "outputs": {
-          "7d74c83b-6d52-48db-a816-1d4992a40947": {
-            "type": "value",
-            "value": "test"
-          }
         }
-      }
-    },
-    "constants": {
-      "ServiceTask_06crg3b": {
-        "my-custom-variable": {
-          "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+      },
+      "properties": {
+        "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "objectVariable",
+          "type": "json",
+          "required": false,
+          "value": 12
         }
-      }
-    },
-    "properties": {
-      "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "objectVariable",
-        "type": "json",
-        "required": false,
-        "value": 12
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-string-variable-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-string-variable-extensions.json
@@ -1,40 +1,42 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "mappings": {
-      "ServiceTask_06crg3b": {
-        "inputs": {
-          "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
-            "type": "variable",
-            "value": "db995012-b417-4cea-a981-cef287de8e4a"
+    "Process_test": {
+      "mappings": {
+        "ServiceTask_06crg3b": {
+          "inputs": {
+            "78ff4945-a09e-4d25-8b91-a9b97e0b2d92": {
+              "type": "variable",
+              "value": "db995012-b417-4cea-a981-cef287de8e4a"
+            },
+            "aa4a9329-71be-4889-8265-398b68536d4a": {
+              "type": "variable",
+              "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+            }
           },
-          "aa4a9329-71be-4889-8265-398b68536d4a": {
-            "type": "variable",
+          "outputs": {
+            "7d74c83b-6d52-48db-a816-1d4992a40947": {
+              "type": "value",
+              "value": "test"
+            }
+          }
+        }
+      },
+      "constants": {
+        "ServiceTask_06crg3b": {
+          "my-custom-variable": {
             "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
           }
-        },
-        "outputs": {
-          "7d74c83b-6d52-48db-a816-1d4992a40947": {
-            "type": "value",
-            "value": "test"
-          }
         }
-      }
-    },
-    "constants": {
-      "ServiceTask_06crg3b": {
-        "my-custom-variable": {
-          "value": "ee9eb6d4-8cd6-4098-8340-13ce2f470faa"
+      },
+      "properties": {
+        "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "stringVariable",
+          "type": "string",
+          "required": false,
+          "value": 27
         }
-      }
-    },
-    "properties": {
-      "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "stringVariable",
-        "type": "string",
-        "required": false,
-        "value": 27
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-extensions-no-value.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-extensions-no-value.json
@@ -1,30 +1,32 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "properties": {
-      "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "integerVariable",
-        "type": "integer",
-        "required": false
-      },
-      "c297ec88-0ecf-4841-9b0f-2ae814957c69": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "stringVariable",
-        "type": "string",
-        "required": false
-      },
-      "c297ec88-0ecf-4841-9b0f-2ae814957c62": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "dateVariable",
-        "type": "date",
-        "required": false
-      },
-      "c297ec88-0ecf-4841-9b0f-2ae814957c64": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
-        "name": "booleanVariable",
-        "type": "boolean",
-        "required": false
+    "Process_x": {
+      "properties": {
+        "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "integerVariable",
+          "type": "integer",
+          "required": false
+        },
+        "c297ec88-0ecf-4841-9b0f-2ae814957c69": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "stringVariable",
+          "type": "string",
+          "required": false
+        },
+        "c297ec88-0ecf-4841-9b0f-2ae814957c62": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "dateVariable",
+          "type": "date",
+          "required": false
+        },
+        "c297ec88-0ecf-4841-9b0f-2ae814957c64": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c68",
+          "name": "booleanVariable",
+          "type": "boolean",
+          "required": false
+        }
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-extensions-with-message-payload-mapping.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-extensions-with-message-payload-mapping.json
@@ -1,32 +1,34 @@
 {
   "id": "process-2826e9c6-8b07-48aa-bd24-51dd5616fe80",
   "extensions": {
-    "constants": {},
-    "mappings": {
-      "IntermediateThrowEvent_0jo6gz9": {
-        "inputs": {
-          "animalMessage": {
-            "type": "value",
-            "value": "cat"
+    "Process_test": {
+      "constants": {},
+      "mappings": {
+        "IntermediateThrowEvent_0jo6gz9": {
+          "inputs": {
+            "animalMessage": {
+              "type": "value",
+              "value": "cat"
+            }
+          }
+        },
+        "IntermediateCatchEvent_1n53e58": {
+          "outputs": {
+            "animal": {
+              "type": "variable",
+              "value": "animalMessage"
+            }
           }
         }
       },
-      "IntermediateCatchEvent_1n53e58": {
-        "outputs": {
-          "animal": {
-            "type": "variable",
-            "value": "animalMessage"
-          }
+      "properties": {
+        "412ac30e-4bdf-475e-b24e-139a851abb8b": {
+          "id": "412ac30e-4bdf-475e-b24e-139a851abb8b",
+          "name": "animal",
+          "type": "string",
+          "value": "",
+          "required": false
         }
-      }
-    },
-    "properties": {
-      "412ac30e-4bdf-475e-b24e-139a851abb8b": {
-        "id": "412ac30e-4bdf-475e-b24e-139a851abb8b",
-        "name": "animal",
-        "type": "string",
-        "value": "",
-        "required": false
       }
     }
   }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-extensions.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-extensions.json
@@ -1,49 +1,51 @@
 {
   "id": "process-db995012-b417-4cea-a981",
   "extensions": {
-    "constants": {
-      "ServiceTask_06crg3b": {
-        "my-custom-variable": {
-          "value": "name2"
+    "Process_x": {
+      "constants": {
+        "ServiceTask_06crg3b": {
+          "my-custom-variable": {
+            "value": "name2"
+          }
         }
-      }
-    },
-    "properties": {
-      "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c48",
-        "name": "integerVariable",
-        "type": "integer",
-        "required": false,
-        "value": 12
       },
-      "c297ec88-0ecf-4841-9b0f-2ae814957c69": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c38",
-        "name": "stringVariable",
-        "type": "string",
-        "required": false,
-        "value": "aloha"
-      },
-      "c297ec88-0ecf-4841-9b0f-2ae814957c62": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c28",
-        "name": "dateVariable",
-        "type": "date",
-        "required": false,
-        "value": "1993-06-03"
-      },
-      "c297ec88-0ecf-4841-9b0f-2ae814957c64": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c18",
-        "name": "booleanVariable",
-        "type": "boolean",
-        "required": false,
-        "value": true
-      },
-      "c297ec88-0ecf-4841-9b0f-2ae814957c67": {
-        "id": "c297ec88-0ecf-4841-9b0f-2ae814957c08",
-        "name": "jsonVariable",
-        "type": "json",
-        "required": false,
-        "value": {
-          "foo": "bar"
+      "properties": {
+        "c297ec88-0ecf-4841-9b0f-2ae814957c68": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c48",
+          "name": "integerVariable",
+          "type": "integer",
+          "required": false,
+          "value": 12
+        },
+        "c297ec88-0ecf-4841-9b0f-2ae814957c69": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c38",
+          "name": "stringVariable",
+          "type": "string",
+          "required": false,
+          "value": "aloha"
+        },
+        "c297ec88-0ecf-4841-9b0f-2ae814957c62": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c28",
+          "name": "dateVariable",
+          "type": "date",
+          "required": false,
+          "value": "1993-06-03"
+        },
+        "c297ec88-0ecf-4841-9b0f-2ae814957c64": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c18",
+          "name": "booleanVariable",
+          "type": "boolean",
+          "required": false,
+          "value": true
+        },
+        "c297ec88-0ecf-4841-9b0f-2ae814957c67": {
+          "id": "c297ec88-0ecf-4841-9b0f-2ae814957c08",
+          "name": "jsonVariable",
+          "type": "json",
+          "required": false,
+          "value": {
+            "foo": "bar"
+          }
         }
       }
     }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/RankMovie.bpmn20.xml
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/RankMovie.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:activiti="http://activiti.org/bpmn" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
-  <bpmn2:process id="RankMovieId" name="rank-movie" isExecutable="true">
+  <bpmn2:process id="Process_RankMovieId" name="rank-movie" isExecutable="true">
     <bpmn2:documentation />
     <bpmn2:startEvent id="StartEvent_1">
       <bpmn2:outgoing>SequenceFlow_02b718w</bpmn2:outgoing>

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/invalid-service-task.bpmn20.xml
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/invalid-service-task.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
-  <bpmn2:process id="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89" name="invalid-service" isExecutable="true">
+  <bpmn2:process id="Process_InvalidTask" name="invalid-service" isExecutable="true">
     <bpmn2:documentation />
     <bpmn2:startEvent id="StartEvent_1">
       <bpmn2:outgoing>SequenceFlow_1tdfy8m</bpmn2:outgoing>

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/message-payload-mapping.bpmn20.xml
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/message-payload-mapping.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
-  <bpmn2:process id="process-2826e9c6-8b07-48aa-bd24-51dd5616fe80" name="messages-process" isExecutable="true">
+  <bpmn2:process id="Process_test" name="messages-process" isExecutable="true">
     <bpmn2:documentation />
     <bpmn2:startEvent id="StartEvent_1">
       <bpmn2:outgoing>SequenceFlow_1mj8fj3</bpmn2:outgoing>

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/two-call-activities.bpmn20.xml
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/two-call-activities.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
-  <bpmn2:process id="process-1722e83c-8f2f-4ddb-85bd-563ef87d279e" name="call" isExecutable="true">
+  <bpmn2:process id="Process_TwoCall" name="call" isExecutable="true">
     <bpmn2:documentation/>
     <bpmn2:startEvent id="StartEvent_1">
       <bpmn2:outgoing>SequenceFlow_0zrl4z8</bpmn2:outgoing>

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/x-19022.bpmn20.xml
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/x-19022.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef" xmlns:modeler="http://activiti.com/modeler" modeler:version="1.0en" modeler:exportDateTime="20180529150437137" modeler:modelId="19022" modeler:modelVersion="1" modeler:modelLastUpdated="1527595380956">
-  <process id="x" name="x" isExecutable="true">
+  <process id="Process_x" name="x" isExecutable="true">
     <startEvent id="startEvent1">
       <extensionElements>
         <modeler:editor-resource-id><![CDATA[startEvent1]]></modeler:editor-resource-id>

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/converter/ProcessModelContentConverter.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/converter/ProcessModelContentConverter.java
@@ -108,7 +108,6 @@ public class ProcessModelContentConverter implements ModelContentConverter<BpmnP
     public void overrideAllProcessDefinition(BpmnProcessModelContent processModelContent,
                                              ReferenceIdOverrider referenceIdOverrider) {
         processModelContent.getBpmnModel().getProcesses().forEach(process -> {
-            referenceIdOverrider.overrideProcessId(process);
             overrideAllIdReferences(process, referenceIdOverrider);
         });
     }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/converter/ReferenceIdOverrider.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/converter/ReferenceIdOverrider.java
@@ -3,7 +3,6 @@ package org.activiti.cloud.services.modeling.converter;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.activiti.bpmn.model.Process;
 import org.activiti.bpmn.model.ReferenceOverrider;
 import org.activiti.bpmn.model.StartEvent;
 import org.activiti.bpmn.model.UserTask;
@@ -33,13 +32,4 @@ public class ReferenceIdOverrider implements ReferenceOverrider {
             startEvent.setFormKey(newFormKey);
         }
     }
-
-    public void overrideProcessId(Process process) {
-        String oldProcessId = process.getId();
-        String newProcessId = modelIdentifiers.get(oldProcessId);
-        if (newProcessId != null) {
-            process.setId(newProcessId);
-        }
-    }
-
 }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -31,11 +31,7 @@ import static org.apache.commons.lang3.StringUtils.removeEnd;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.transaction.Transactional;
@@ -144,11 +140,7 @@ public class ModelServiceImpl implements ModelService{
         ModelType modelType = findModelType(model);
         model.setProject(project);
         if (model.getExtensions() == null) {
-            if (PROCESS.equals(modelType.getName())) {
-                model.setExtensions(new Extensions().getAsMap());
-            } else if (isJsonContentType(model.getContentType())) {
-                model.setExtensions(new HashMap<String, Object>());
-            }
+          model.setExtensions(new HashMap<String,Object>());
         }
         return modelRepository.createModel(model);
     }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -179,7 +179,7 @@ public class ModelServiceImpl implements ModelService{
         Model fullModel = findModelById(model.getId()).orElse(model);
         Model modelToFile = buildModel(fullModel.getType(),
                                        fullModel.getName());
-        modelToFile.setId(fullModel.getType().toLowerCase().concat("-"+model.getId()));
+        modelToFile.setId(fullModel.getType().toLowerCase().concat("-").concat(model.getId()));
         modelToFile.setExtensions(fullModel.getExtensions());
 
         FileContent extensionsFileContent = new FileContent(getExtensionsFilename(model),

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsModelValidator.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsModelValidator.java
@@ -91,8 +91,7 @@ public class ProcessExtensionsModelValidator extends ExtensionsJsonSchemaValidat
                                                                    ValidationContext validationContext,
                                                                    BpmnProcessModelContent bpmnModel) {
         return bpmnModel.getBpmnModel().getProcesses().stream()
-            .map(process -> process.getId())
-            .map(processId -> this.retrieveExtensionByProcessId(model, processId))
+            .map(process -> this.retrieveExtensionByProcessId(model, process.getId()))
             .flatMap(extensions -> validateProcessExtension(extensions, validationContext, bpmnModel));
     }
 

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsModelValidator.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsModelValidator.java
@@ -18,10 +18,7 @@ package org.activiti.cloud.services.modeling.validation.extensions;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.removeStart;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -93,14 +90,26 @@ public class ProcessExtensionsModelValidator extends ExtensionsJsonSchemaValidat
     protected Stream<ModelValidationError> validateBpmnModel(Model model,
                                                                    ValidationContext validationContext,
                                                                    BpmnProcessModelContent bpmnModel) {
+        return bpmnModel.getBpmnModel().getProcesses().stream()
+            .map(process -> process.getId())
+            .map(processId -> this.retrieveExtensionByProcessId(model, processId))
+            .flatMap(extensions -> validateProcessExtension(extensions, validationContext, bpmnModel));
+    }
 
-        return jsonExtensionsConverter.tryConvertToEntity(model.getExtensions()).
-                map(extensions -> processExtensionsValidators
-                        .stream()
-                        .flatMap(validator -> validator.validateExtensions(extensions,
-                                                                 bpmnModel,
-                                                                 validationContext)))
-                .orElseGet(Stream::empty);
+    private Map<String, Object> retrieveExtensionByProcessId(Model model, String processId){
+        return model.getExtensions() != null ? (Map<String, Object>) model.getExtensions().get(processId) : null;
+    }
+
+    private Stream<ModelValidationError> validateProcessExtension(Map<String,Object> processExtension,
+                                                                  ValidationContext validationContext,
+                                                                  BpmnProcessModelContent bpmnModel){
+        return jsonExtensionsConverter.tryConvertToEntity(processExtension)
+            .map(extensions -> processExtensionsValidators
+                .stream()
+                .flatMap(validator -> validator.validateExtensions(extensions,
+                    bpmnModel,
+                    validationContext)))
+            .orElseGet(Stream::empty);
     }
 
     private Optional<Model> findProcessModelInContext(String modelId,

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
@@ -8,9 +8,19 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
+        "Process_.": {
+          "$ref": "#/definitions/extension-element"
+        }
+      }
+    },
+    "extension-element": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
         "properties": { "$ref": "#/definitions/properties" },
         "mappings": { "$ref": "#/definitions/mappings" },
-        "constants": { "$ref": "#/definitions/constants" }
+        "constants": { "$ref": "#/definitions/constants" },
+        "assignments": { "$ref": "#/definitions/assignments" }
       }
     },
     "properties": {
@@ -280,6 +290,33 @@
       "properties": {
         "value": {
           "type": "string"
+        }
+      }
+    },
+    "assignments": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/assignment-property"
+        }
+      }
+    },
+    "assignment-property": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "assignment": {
+          "type": "string",
+          "enum": ["assignee", "candidates"],
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": ["static", "identity", "expression"],
+          "additionalProperties": false
         }
       }
     }

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/converter/ProcessModelContentConverterTest.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/converter/ProcessModelContentConverterTest.java
@@ -62,7 +62,6 @@ public class ProcessModelContentConverterTest {
 
         processModelContentConverter.overrideAllProcessDefinition(processModelContent, referenceIdOverrider);
 
-        verify(referenceIdOverrider).overrideProcessId(process);
         verify(flowElement).accept(referenceIdOverrider);
     }
 

--- a/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/converter/ReferenceIdOverriderTest.java
+++ b/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/converter/ReferenceIdOverriderTest.java
@@ -86,24 +86,4 @@ public class ReferenceIdOverriderTest {
 
         assertThat(startEvent.getFormKey()).isEqualTo("notNewFormKey");
     }
-
-    @Test
-    public void should_overrideProcessId_when_newProcessId() {
-        Process process = new Process();
-        process.setId("oldProcessId");
-
-        referenceIdOverrider.overrideProcessId(process);
-
-        assertThat(process.getId()).isEqualTo("newProcessId");
-    }
-
-    @Test
-    public void should_notOverrideProcessId_when_processIdNotFound() {
-        Process process = new Process();
-        process.setId("notNewProcessId");
-
-        referenceIdOverrider.overrideProcessId(process);
-
-        assertThat(process.getId()).isEqualTo("notNewProcessId");
-    }
 }


### PR DESCRIPTION
This PR will change the extension schema validation to allow the support for the swimlanes inside the process definitions. The process Id will be the extra key added into the extensions json object which will contains all the attributes relatives to that process.
Due to this the process id rewriting that was happening before has been removed as it doesn't make sense anymore